### PR TITLE
Update version of application insights node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "prepublish": "gulp"
     },
     "dependencies": {
-        "applicationinsights": "0.15.6",
+        "applicationinsights": "0.15.19",
         "winreg": "0.0.13"
     },
     "devDependencies": {


### PR DESCRIPTION
Update the version of the application insights node module to fix an issue where the iKey is not contained in the "name" field sent to application insights.

As it currently stands, the "name" field in the telemetry data sent will always be "Microsoft.ApplicationInsights.Event", and it does not contain the iKey as part of the name as it should. This is a defect from using an older version of the application insights node module.

In version 0.15.6 of applicationinsights, this is the code for setting the "name" field:
https://github.com/Microsoft/ApplicationInsights-node.js/blob/v0.15.6/Library/Client.ts#L162

Compare this to the code in the newest version of the library, 0.15.19, which correctly puts the iKey into the "name" field:
https://github.com/Microsoft/ApplicationInsights-node.js/blob/v0.15.19/Library/Client.ts#L207
