### PR TITLE
Stop collecting dependency events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-extension-telemetry",
     "description": "A module for first party microsoft extensions to report consistent telemetry.",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "author": {
         "name": "Microsoft Corporation"
     },

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -34,6 +34,7 @@ export default class TelemetryReporter extends vscode.Disposable {
                 .setAutoCollectRequests(false)
                 .setAutoCollectPerformance(false)
                 .setAutoCollectExceptions(false)
+                .setAutoCollectDependencies(false)
                 .setOfflineMode(true)
                 .start()
                 .client;

--- a/typings_patches/applicationinsights/index.d.ts
+++ b/typings_patches/applicationinsights/index.d.ts
@@ -470,6 +470,12 @@ interface ApplicationInsights {
      */
     setAutoCollectConsole(value: boolean): ApplicationInsights;
     /**
+     * Sets the state of dependency tracking (enabled by default)
+     * @param value if true dependencies will be sent to Application Insights
+     * @returns {ApplicationInsights} this interface
+     */
+    setAutoCollectDependencies(value: boolean): ApplicationInsights;
+    /**
      * Sets the state of exception tracking (enabled by default)
      * @param value if true uncaught exceptions will be sent to Application Insights
      * @returns {ApplicationInsights} this interface


### PR DESCRIPTION
Since late February the extension telelmetry pipeline is seeing events like the below

![image](https://cloud.githubusercontent.com/assets/16890566/25144550/0e3aea2e-2423-11e7-9916-22595b87b224.png)

Root cause: When we upgraded to use `0.18.0` version of appinsights SDK, it had this extra feature of collecting "dependency events" which we hadnt disabled

