### PR TITLE
Set {user,session}_id for stats on Azure portal

### DIFF
--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -41,8 +41,9 @@ export default class TelemetryReporter extends vscode.Disposable {
         
         const common = this.getCommonProperties();
         this.appInsightsClient.commonProperties = common;
-        this.appInsightsClient.context.userId = common["common.vscodemachineid"];
-        this.appInsightsClient.context.sessionId = common["common.vscodesessionid"];
+        const { userId, sessionId } = this.appInsightsClient.context.keys;
+        this.appInsightsClient.context.tags[userId] = common["common.vscodemachineid"];
+        this.appInsightsClient.context.tags[sessionId] = common["common.vscodesessionid"];
 
         //check if it's an Asimov key to change the endpoint
         if (key && key.indexOf('AIF-') === 0) {

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -39,7 +39,10 @@ export default class TelemetryReporter extends vscode.Disposable {
            this.appInsightsClient = appInsights.defaultClient;
         }
         
-        this.appInsightsClient.commonProperties = this.getCommonProperties();
+        const common = this.getCommonProperties();
+        this.appInsightsClient.commonProperties = common;
+        this.appInsightsClient.context.tags.userId = common["common.vscodemachineid"];
+        this.appInsightsClient.context.tags.sessionId = common["common.vscodesessionid"];
 
         //check if it's an Asimov key to change the endpoint
         if (key && key.indexOf('AIF-') === 0) {

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -41,8 +41,8 @@ export default class TelemetryReporter extends vscode.Disposable {
         
         const common = this.getCommonProperties();
         this.appInsightsClient.commonProperties = common;
-        this.appInsightsClient.context.tags.userId = common["common.vscodemachineid"];
-        this.appInsightsClient.context.tags.sessionId = common["common.vscodesessionid"];
+        this.appInsightsClient.context.userId = common["common.vscodemachineid"];
+        this.appInsightsClient.context.sessionId = common["common.vscodesessionid"];
 
         //check if it's an Asimov key to change the endpoint
         if (key && key.indexOf('AIF-') === 0) {


### PR DESCRIPTION
In order to use things like the [user retention tools in the Azure portal](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-usage-segmentation
), [user_id and session_id must be set](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-usage-send-user-context).

I currently get this sadness:

![image](https://user-images.githubusercontent.com/3104/37846263-5033780c-2e8a-11e8-9ddc-03ce008ee405.png)

How do you all deal with this? Is it because you have other tools do slice the data?
