### PR TITLE
Remove SQM properties from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ not to send telemetry data.
 - `common.vscodeversion` 
 - `common.os`
 - `common.platformversion`
-- `common.sqmid`  
-- `common.sqmmachineid`
 
 # License
 [MIT](LICENSE)


### PR DESCRIPTION
They seem to be left over from c1a86de2344f425a779f759ef5d185626cf37a86.