### PR TITLE
Log telemetry events to file when in verbose mode

### DIFF
--- a/lib/telemetryReporter.d.ts
+++ b/lib/telemetryReporter.d.ts
@@ -7,14 +7,17 @@ export default class TelemetryReporter extends vscode.Disposable {
     private toDispose;
     private static TELEMETRY_CONFIG_ID;
     private static TELEMETRY_CONFIG_ENABLED_ID;
+    private logFilePath;
+    private logStream;
     constructor(extensionId: string, extensionVersion: string, key: string);
-    private updateUserOptIn(key);
-    private createAppInsightsClient(key);
-    private getCommonProperties();
+    private updateUserOptIn;
+    private createAppInsightsClient;
+    private getCommonProperties;
     sendTelemetryEvent(eventName: string, properties?: {
         [key: string]: string;
-    }, measures?: {
+    }, measurements?: {
         [key: string]: number;
     }): void;
     dispose(): Promise<any>;
+    private format;
 }

--- a/lib/telemetryReporter.d.ts
+++ b/lib/telemetryReporter.d.ts
@@ -19,5 +19,4 @@ export default class TelemetryReporter extends vscode.Disposable {
         [key: string]: number;
     }): void;
     dispose(): Promise<any>;
-    private format;
 }

--- a/lib/telemetryReporter.d.ts
+++ b/lib/telemetryReporter.d.ts
@@ -7,7 +7,6 @@ export default class TelemetryReporter extends vscode.Disposable {
     private toDispose;
     private static TELEMETRY_CONFIG_ID;
     private static TELEMETRY_CONFIG_ENABLED_ID;
-    private logFilePath;
     private logStream;
     constructor(extensionId: string, extensionVersion: string, key: string);
     private updateUserOptIn;

--- a/lib/telemetryReporter.js
+++ b/lib/telemetryReporter.js
@@ -28,7 +28,7 @@ var TelemetryReporter = /** @class */ (function (_super) {
         _this.userOptIn = false;
         _this.toDispose = [];
         var logFilePath = process.env['VSCODE_LOGS'] || '';
-        if (logFilePath && extensionId && process.env['VSCODE_LOG_STACK'] === 'true') {
+        if (logFilePath && extensionId && process.env['VSCODE_LOG_LEVEL'] === 'trace') {
             logFilePath = path.join(logFilePath, extensionId + ".txt");
             _this.logStream = fs.createWriteStream(logFilePath, { flags: 'a', encoding: 'utf8', autoClose: true });
         }

--- a/lib/telemetryReporter.js
+++ b/lib/telemetryReporter.js
@@ -28,9 +28,9 @@ var TelemetryReporter = /** @class */ (function (_super) {
         _this.userOptIn = false;
         _this.toDispose = [];
         _this.logFilePath = process.env['VSCODE_LOGS'] || '';
-        if (_this.logFilePath) {
+        if (_this.logFilePath && extensionId) {
             _this.logFilePath = path.join(_this.logFilePath, extensionId + ".txt");
-            _this.logStream = fs.createWriteStream(_this.logFilePath, { flags: 'a', encoding: 'utf8' });
+            _this.logStream = fs.createWriteStream(_this.logFilePath, { flags: 'a', encoding: 'utf8', autoClose: true });
         }
         _this.updateUserOptIn(key);
         _this.toDispose.push(vscode.workspace.onDidChangeConfiguration(function () { return _this.updateUserOptIn(key); }));
@@ -101,13 +101,17 @@ var TelemetryReporter = /** @class */ (function (_super) {
                 measurements: measurements
             });
             if (process.env['VSCODE_LOG_STACK'] === 'true' && this.logStream) {
-                this.logStream.write(this.format(["telemetry/" + eventName, { properties: properties, measurements: measurements }, '\n']));
+                this.logStream.write("telemetry/" + eventName + " " + JSON.stringify({ properties: properties, measurements: measurements }) + "\n");
             }
         }
     };
     TelemetryReporter.prototype.dispose = function () {
         var _this = this;
-        return new Promise(function (resolve) {
+        var flushEventsToLogger = new Promise(function (resolve) {
+            _this.logStream.on('finish', resolve);
+            _this.logStream.end();
+        });
+        var flushEventsToAI = new Promise(function (resolve) {
             if (_this.appInsightsClient) {
                 _this.appInsightsClient.flush({
                     callback: function () {
@@ -121,20 +125,7 @@ var TelemetryReporter = /** @class */ (function (_super) {
                 resolve(void 0);
             }
         });
-    };
-    TelemetryReporter.prototype.format = function (args) {
-        var result = '';
-        for (var i = 0; i < args.length; i++) {
-            var a = args[i];
-            if (typeof a === 'object') {
-                try {
-                    a = JSON.stringify(a);
-                }
-                catch (e) { }
-            }
-            result += (i > 0 ? ' ' : '') + a;
-        }
-        return result;
+        return Promise.all([flushEventsToAI, flushEventsToLogger]);
     };
     TelemetryReporter.TELEMETRY_CONFIG_ID = 'telemetry';
     TelemetryReporter.TELEMETRY_CONFIG_ENABLED_ID = 'enableTelemetry';

--- a/lib/telemetryReporter.js
+++ b/lib/telemetryReporter.js
@@ -101,8 +101,7 @@ var TelemetryReporter = /** @class */ (function (_super) {
                 measurements: measurements
             });
             if (process.env['VSCODE_LOG_STACK'] === 'true' && this.logStream) {
-                this.logStream.write('\n');
-                this.logStream.write(this.format(["telemetry/" + eventName, { properties: properties, measurements: measurements }]));
+                this.logStream.write(this.format(["telemetry/" + eventName, { properties: properties, measurements: measurements }, '\n']));
             }
         }
     };

--- a/lib/telemetryReporter.js
+++ b/lib/telemetryReporter.js
@@ -14,7 +14,9 @@ var __extends = (this && this.__extends) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 process.env['APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL'] = true;
+var fs = require("fs");
 var os = require("os");
+var path = require("path");
 var vscode = require("vscode");
 var appInsights = require("applicationinsights");
 var TelemetryReporter = /** @class */ (function (_super) {
@@ -25,6 +27,11 @@ var TelemetryReporter = /** @class */ (function (_super) {
         _this.extensionVersion = extensionVersion;
         _this.userOptIn = false;
         _this.toDispose = [];
+        _this.logFilePath = process.env['VSCODE_LOGS'] || '';
+        if (_this.logFilePath) {
+            _this.logFilePath = path.join(_this.logFilePath, extensionId + ".txt");
+            _this.logStream = fs.createWriteStream(_this.logFilePath, { flags: 'a', encoding: 'utf8' });
+        }
         _this.updateUserOptIn(key);
         _this.toDispose.push(vscode.workspace.onDidChangeConfiguration(function () { return _this.updateUserOptIn(key); }));
         return _this;
@@ -86,13 +93,17 @@ var TelemetryReporter = /** @class */ (function (_super) {
         }
         return commonProperties;
     };
-    TelemetryReporter.prototype.sendTelemetryEvent = function (eventName, properties, measures) {
+    TelemetryReporter.prototype.sendTelemetryEvent = function (eventName, properties, measurements) {
         if (this.userOptIn && eventName && this.appInsightsClient) {
             this.appInsightsClient.trackEvent({
                 name: this.extensionId + "/" + eventName,
                 properties: properties,
-                measurements: measures
+                measurements: measurements
             });
+            if (process.env['VSCODE_LOG_STACK'] === 'true' && this.logStream) {
+                this.logStream.write('\n');
+                this.logStream.write(this.format(["telemetry/" + eventName, { properties: properties, measurements: measurements }]));
+            }
         }
     };
     TelemetryReporter.prototype.dispose = function () {
@@ -111,6 +122,20 @@ var TelemetryReporter = /** @class */ (function (_super) {
                 resolve(void 0);
             }
         });
+    };
+    TelemetryReporter.prototype.format = function (args) {
+        var result = '';
+        for (var i = 0; i < args.length; i++) {
+            var a = args[i];
+            if (typeof a === 'object') {
+                try {
+                    a = JSON.stringify(a);
+                }
+                catch (e) { }
+            }
+            result += (i > 0 ? ' ' : '') + a;
+        }
+        return result;
     };
     TelemetryReporter.TELEMETRY_CONFIG_ID = 'telemetry';
     TelemetryReporter.TELEMETRY_CONFIG_ENABLED_ID = 'enableTelemetry';

--- a/lib/telemetryReporter.js
+++ b/lib/telemetryReporter.js
@@ -27,10 +27,10 @@ var TelemetryReporter = /** @class */ (function (_super) {
         _this.extensionVersion = extensionVersion;
         _this.userOptIn = false;
         _this.toDispose = [];
-        _this.logFilePath = process.env['VSCODE_LOGS'] || '';
-        if (_this.logFilePath && extensionId) {
-            _this.logFilePath = path.join(_this.logFilePath, extensionId + ".txt");
-            _this.logStream = fs.createWriteStream(_this.logFilePath, { flags: 'a', encoding: 'utf8', autoClose: true });
+        var logFilePath = process.env['VSCODE_LOGS'] || '';
+        if (logFilePath && extensionId && process.env['VSCODE_LOG_STACK'] === 'true') {
+            logFilePath = path.join(logFilePath, extensionId + ".txt");
+            _this.logStream = fs.createWriteStream(logFilePath, { flags: 'a', encoding: 'utf8', autoClose: true });
         }
         _this.updateUserOptIn(key);
         _this.toDispose.push(vscode.workspace.onDidChangeConfiguration(function () { return _this.updateUserOptIn(key); }));
@@ -100,7 +100,7 @@ var TelemetryReporter = /** @class */ (function (_super) {
                 properties: properties,
                 measurements: measurements
             });
-            if (process.env['VSCODE_LOG_STACK'] === 'true' && this.logStream) {
+            if (this.logStream) {
                 this.logStream.write("telemetry/" + eventName + " " + JSON.stringify({ properties: properties, measurements: measurements }) + "\n");
             }
         }
@@ -108,6 +108,9 @@ var TelemetryReporter = /** @class */ (function (_super) {
     TelemetryReporter.prototype.dispose = function () {
         var _this = this;
         var flushEventsToLogger = new Promise(function (resolve) {
+            if (!_this.logStream) {
+                return resolve(void 0);
+            }
             _this.logStream.on('finish', resolve);
             _this.logStream.end();
         });

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -103,8 +103,7 @@ export default class TelemetryReporter extends vscode.Disposable {
             })
 
             if (process.env['VSCODE_LOG_STACK'] === 'true' && this.logStream) {
-                this.logStream.write('\n');
-                this.logStream.write(this.format([`telemetry/${eventName}`, { properties, measurements }]));
+                this.logStream.write(this.format([`telemetry/${eventName}`, { properties, measurements }, '\n']));
             }
         }
     }

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -25,7 +25,7 @@ export default class TelemetryReporter extends vscode.Disposable {
     constructor(private extensionId: string, private extensionVersion: string, key: string) {
         super(() => this.toDispose.forEach((d) => d && d.dispose()))
         let logFilePath = process.env['VSCODE_LOGS'] || '';
-        if (logFilePath && extensionId && process.env['VSCODE_LOG_STACK'] === 'true') {
+        if (logFilePath && extensionId && process.env['VSCODE_LOG_LEVEL'] === 'trace') {
             logFilePath = path.join(logFilePath, `${extensionId}.txt`);
             this.logStream = fs.createWriteStream(logFilePath, { flags: 'a', encoding: 'utf8', autoClose: true });
         }


### PR DESCRIPTION
Log telemetry events to file when in verbose mode
Related to https://github.com/Microsoft/vscode/issues/54001
- VSCODE_LOGS has the path to the log folder form https://github.com/Microsoft/vscode/blob/e7058655de73b5a19a5b4286079ce68cb7c13523/src/vs/platform/environment/node/environmentService.ts#L211
- VSCODE_LOG_STACK tracks if verbose logging is enabled from https://github.com/Microsoft/vscode/blob/5fae91d61f12726e149fe5baed342eac2fbf8f88/src/vs/workbench/services/extensions/electron-browser/extensionHost.ts#L144. But since this gets enabled for insiders all the time, this is not a great choice for the current scenario.
- [LogLevel](https://github.com/Microsoft/vscode/blob/1.25.1/src/vs/vscode.proposed.d.ts#L202-L206) is part of the proposed api. Once it makes it to stable, we can use that. Until then we use a new env var VSCODE_LOG_LEVEL to pass the log level from core. See https://github.com/Microsoft/vscode/commit/9645f0219a5960a1b0df1cdf9dc20e1a7f646dd6

cc @jrieken @bpasero 