### PR TITLE
add anonymizePaths function

### DIFF
--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -109,6 +109,14 @@ export default class TelemetryReporter {
             }
         }
     }
+    
+    /**
+     * replaces username with anon to respect privacy of user
+     */
+    public anonymizePaths(input:string){
+        if(input == null) return input
+        return input.replace(new RegExp('\\'+sep+userInfo().username, 'g'), sep+'anon')
+    }
 
     public dispose(): Promise<any> {
 


### PR DESCRIPTION
Currently mostly working in https://github.com/Almenon/AREPL-vscode

29/34 events out of the past week were sucessfully anonymized.
Not sure why the other 5 didn't work. 

For example, `Error: spawn C:\Users\smith\Anaconda3\envs\py36 ENOENT` becomes `Error: spawn C:\Users\anon\Anaconda3\envs\py36 ENOENT`

works with linux too:
`Error: spawn /Users/smith/anaconda3/bin/python` becomes `Error: spawn /Users/anon/anaconda3/bin/python`

or:
`/home/smith/.vscode/extensions/almenon.arepl-1.0.13/node_modules/arepl-backend/python/pythonEvaluator.py` becomes `/home/anon/.vscode/extensions/almenon.arepl-1.0.13/node_modules/arepl-backend/python/pythonEvaluator.py`