### PR TITLE
Extend the telemetryReporter to include exception message types.

### DIFF
--- a/lib/telemetryReporter.d.ts
+++ b/lib/telemetryReporter.d.ts
@@ -16,5 +16,10 @@ export default class TelemetryReporter {
     }, measurements?: {
         [key: string]: number;
     }): void;
+    sendTelemetryException(error: Error, properties?: {
+        [key: string]: string;
+    }, measurements?: {
+        [key: string]: number;
+    }): void;
     dispose(): Promise<any>;
 }

--- a/lib/telemetryReporter.js
+++ b/lib/telemetryReporter.js
@@ -97,6 +97,18 @@ var TelemetryReporter = /** @class */ (function () {
             }
         }
     };
+    TelemetryReporter.prototype.sendTelemetryException = function (error, properties, measurements) {
+        if (this.userOptIn && error && this.appInsightsClient) {
+            this.appInsightsClient.trackException({
+                exception: error,
+                properties: properties,
+                measurements: measurements
+            });
+            if (this.logStream) {
+                this.logStream.write("telemetry/" + error.name + " " + error.message + " " + JSON.stringify({ properties: properties, measurements: measurements }) + "\n");
+            }
+        }
+    };
     TelemetryReporter.prototype.dispose = function () {
         var _this = this;
         this.configListener.dispose();

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -110,6 +110,20 @@ export default class TelemetryReporter {
         }
     }
 
+    public sendTelemetryException(error: Error, properties?: { [key: string]: string }, measurements?: { [key: string]: number }): void {
+        if (this.userOptIn && error && this.appInsightsClient) {
+            this.appInsightsClient.trackException({
+                exception: error,
+                properties: properties,
+                measurements: measurements
+            })
+
+            if (this.logStream) {
+                this.logStream.write(`telemetry/${error.name} ${error.message} ${JSON.stringify({ properties, measurements })}\n`);
+            }
+        }
+    }
+
     public dispose(): Promise<any> {
 
         this.configListener.dispose();


### PR DESCRIPTION
Extend the core telemetry package to include exception message types.  
The current model is that everything is an event and we need to ensure that exceptions from extension reflect the proper type.