### PR TITLE
fix: use property key instead of value for function change

### DIFF
--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -227,7 +227,7 @@ export default class TelemetryReporter {
 
     public sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measurements?: { [key: string]: number }): void {
         if (this.userOptIn && eventName && this.appInsightsClient) {
-            const cleanProperties = this.cloneAndChange(properties, (prop: string) => this.anonymizeFilePaths(prop, this.firstParty));
+            const cleanProperties = this.cloneAndChange(properties, (prop: string) => this.anonymizeFilePaths(properties[prop], this.firstParty));
 
             this.appInsightsClient.trackEvent({
                 name: `${this.extensionId}/${eventName}`,
@@ -248,14 +248,14 @@ export default class TelemetryReporter {
             // if we have no errorProps, assume all are error props
             const cleanProperties = this.cloneAndChange(properties, (prop: string) => {
                 if (this.shouldSendErrorTelemetry()) {
-                    return this.anonymizeFilePaths(prop, this.firstParty)
+                    return this.anonymizeFilePaths(properties[prop], this.firstParty)
                 }
 
                 if (errorProps === undefined || errorProps.indexOf(prop) !== -1) {
                     return 'REDACTED';
                 }
 
-                return this.anonymizeFilePaths(prop, this.firstParty);
+                return this.anonymizeFilePaths(properties[prop], this.firstParty);
             });
 
             this.appInsightsClient.trackEvent({
@@ -272,7 +272,7 @@ export default class TelemetryReporter {
 
     public sendTelemetryException(error: Error, properties?: { [key: string]: string }, measurements?: { [key: string]: number }): void {
         if (this.shouldSendErrorTelemetry() && this.userOptIn && error && this.appInsightsClient) {
-            const cleanProperties = this.cloneAndChange(properties, (prop: string) => this.anonymizeFilePaths(prop, this.firstParty));
+            const cleanProperties = this.cloneAndChange(properties, (prop: string) => this.anonymizeFilePaths(properties[prop], this.firstParty));
 
             this.appInsightsClient.trackException({
                 exception: error,

--- a/src/telemetryReporter.ts
+++ b/src/telemetryReporter.ts
@@ -166,7 +166,7 @@ export default class TelemetryReporter {
 
         const ret: { [key: string ]: string } = {};
         for (const key in obj) {
-            ret[key] = change(obj[key]);
+            ret[key] = change(key);
         }
 
         return ret;


### PR DESCRIPTION
From my understanding, argument for change function is property key not value.

Other issues:
1. In package.json vscode engine version is 1.5.0, I believe it's not right, because it's the same with this module's version. 
2. Minimun vscode engine version should be pointed out in readme, and from my understanding it's ^1.40.0, or function shouldSendErrorTelemetry will have issues.
