### PR TITLE
Avoid collecting computer hostname

### DIFF
--- a/lib/telemetryReporter.js
+++ b/lib/telemetryReporter.js
@@ -53,8 +53,9 @@ var TelemetryReporter = /** @class */ (function () {
                 .setAutoCollectDependencies(false)
                 .setAutoDependencyCorrelation(false)
                 .setAutoCollectConsole(false)
-                .setUseDiskRetryCaching(true)
-                .start();
+                .setUseDiskRetryCaching(true);
+            appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = "vscode";
+            appInsights.start();
             this.appInsightsClient = appInsights.defaultClient;
         }
         this.appInsightsClient.commonProperties = this.getCommonProperties();


### PR DESCRIPTION
It is common for example for Apple devices to have a hostname with owner's first name in it, such as `Radek's MacBook`.

I'm not sure if (client) hostname can be considered as PII explicitly - probably not in isolation, but also I don't see why such thing should be collected _by default_.

Therefore this PR proposes to override this to `vscode`. If there is any better, more elegant solution, I'm open to it.

![Screenshot 2021-02-19 at 09 43 27](https://user-images.githubusercontent.com/287584/108487233-f1a95780-7296-11eb-8025-7ef2a3d52542.png)
