### PR TITLE
Add safer common property assignment for bool

### DIFF
--- a/src/common/baseTelemetryReporter.ts
+++ b/src/common/baseTelemetryReporter.ts
@@ -148,7 +148,7 @@ export class BaseTelemtryReporter {
 			commonProperties["common.vscodemachineid"] = vscode.env.machineId;
 			commonProperties["common.vscodesessionid"] = vscode.env.sessionId;
 			commonProperties["common.vscodeversion"] = vscode.version;
-			commonProperties["common.isnewappinstall"] = vscode.env.isNewAppInstall;
+			commonProperties["common.isnewappinstall"] = vscode.env.isNewAppInstall.toString();
 
 			switch (vscode.env.uiKind) {
 				case vscode.UIKind.Web:


### PR DESCRIPTION
### Description
`vscode.env.isNewAppInstall` being a boolean disrupts the new `anonymizeFilePaths` function, as it expects all properties to be strings AFAIK.

### Bug Investigation
```typescript
// sanitize with configured cleanup patterns
for (const regexp of cleanupPatterns) {
	updatedStack = updatedStack.replace(regexp, "");
}
```

```typescript
/**
* Given an error stack cleans up the file paths within
* @param stack The stack to clean
* @param anonymizeFilePaths Whether or not to clean the file paths or anonymize them as well
* @returns The cleaned stack
*/
private anonymizeFilePaths(stack?: string, anonymizeFilePaths?: boolean): string {
```

```
[2021-08-22 11:25:23.651] [exthost] [error] TypeError: updatedStack.replace is not a function
	at TelemetryReporter.anonymizeFilePaths (c:\Users\ryanl\dev\vscode-coverage-gutters\node_modules\vscode-extension-telemetry\lib\telemetryReporter.node.js:16787:32)
	at c:\Users\ryanl\dev\vscode-coverage-gutters\node_modules\vscode-extension-telemetry\lib\telemetryReporter.node.js:16826:18
	at TelemetryReporter.cloneAndChange (c:\Users\ryanl\dev\vscode-coverage-gutters\node_modules\vscode-extension-telemetry\lib\telemetryReporter.node.js:16702:15)
	at TelemetryReporter.sendTelemetryErrorEvent (c:\Users\ryanl\dev\vscode-coverage-gutters\node_modules\vscode-extension-telemetry\lib\telemetryReporter.node.js:16824:33)
	at CrashReporter.sendErrorEvent (c:\Users\ryanl\dev\vscode-coverage-gutters\out\src\extension\crashreporter.js:24:23)
	at Gutters.handleError (c:\Users\ryanl\dev\vscode-coverage-gutters\out\src\extension\gutters.js:94:28)
	at Gutters.<anonymous> (c:\Users\ryanl\dev\vscode-coverage-gutters\out\src\extension\gutters.js:47:22)
	at Generator.throw (<anonymous>)
	at rejected (c:\Users\ryanl\dev\vscode-coverage-gutters\out\src\extension\gutters.js:6:65) coverage-gutters.displayCoverage
```

### Fix
Decided keeping all the possible "stacks" as strings is probably the best, so I simply do a `toString` on the boolean in the `getCommonProperties` function. It might also be useful to add tests to this repo if people start using it more 🤔 not sure what you folks might want for a test skeleton / setup though, so I didn't add any...

@lramos15