### PR TITLE
node: Avoid collecting user hostnames

### DIFF
--- a/src/node/telemetryReporter.ts
+++ b/src/node/telemetryReporter.ts
@@ -32,6 +32,7 @@ class AppInsightsAppender implements ITelemetryAppender {
 			this._appInsightsClient.context.tags[this._appInsightsClient.context.keys.userId] = vscode.env.machineId;
 			this._appInsightsClient.context.tags[this._appInsightsClient.context.keys.sessionId] = vscode.env.sessionId;
 			this._appInsightsClient.context.tags[this._appInsightsClient.context.keys.cloudRole] = vscode.env.appName;
+			this._appInsightsClient.context.tags[this._appInsightsClient.context.keys.cloudRoleInstance] = vscode.env.appName;
 		}
 		//check if it's an Asimov key to change the endpoint
 		if (key && key.indexOf("AIF-") === 0) {


### PR DESCRIPTION
This is a follow-up to https://github.com/microsoft/vscode-extension-telemetry/commit/1bd0f0cf1ccd1e584ef70f2e5aa95f028e9276d4 and https://github.com/microsoft/vscode-extension-telemetry/pull/57 respectively.

It seems that in my original PR I made the mistake of either picking the wrong tag name and/or misinterpreting the results of my testing in AppInsights UI.

Either way the library still collects the hostname under `cloudRoleInstance` (prior to this patch).

I left the original override for `cloudRole` there as `Visual Studio Code` still seems more relevant than `Web` in this context.

### Before patch

![Screenshot 2021-09-13 at 13 52 50](https://user-images.githubusercontent.com/287584/133087407-24120af0-b3c9-46b7-a491-172bafb1aa65.png)

### After patch

![Screenshot 2021-09-13 at 13 56 05](https://user-images.githubusercontent.com/287584/133087423-4911be9e-8c52-4780-84b3-447159bd3f46.png)
