### PR TITLE
Add ReplacementOptions to filter telemetry events

### DIFF
--- a/lib/telemetryReporter.d.ts
+++ b/lib/telemetryReporter.d.ts
@@ -13,14 +13,32 @@ export interface RawTelemetryEventProperties {
 export interface TelemetryEventMeasurements {
 	readonly [key: string]: number;
 }
+
+/**
+ * A replacement option for the app insights client. This allows the appender to filter out any sensitive or unnecessary information from the telemetry server.
+ */
+ export interface ReplacementOption {
+
+	/**
+	 * A regular expression matching any property to be removed or replaced from the telemetry server.
+	 */
+	lookup: RegExp;
+
+	/**
+	 * The replacement value for the property. If not present or undefined, the property will be removed.
+	 */
+	replacementString?: string;
+}
+
 export default class TelemetryReporter {
 	/**
 	 * @param extensionId The id of your extension
 	 * @param extensionVersion The version of your extension
 	 * @param key The app insights key
 	 * @param firstParty Whether or not the telemetry is first party (i.e from Microsoft / GitHub)
+	 * @param replacementOptions A list of replacement options for the app insights client. This allows the appender to filter out any sensitive or unnecessary information from the telemetry server.
 	 */
-	constructor(extensionId: string, extensionVersion: string, key: string, firstParty?: boolean);
+	constructor(extensionId: string, extensionVersion: string, key: string, firstParty?: boolean, replacementOptions?: ReplacementOption[]);
 
 	/**
 	 * A string representation of the current level of telemetry being collected

--- a/src/common/baseTelemetryReporter.ts
+++ b/src/common/baseTelemetryReporter.ts
@@ -17,6 +17,22 @@ export interface ITelemetryAppender {
 	instantiateAppender(): void;
 }
 
+/**
+ * A replacement option for the app insights client. This allows the appender to filter out any sensitive or unnecessary information from the telemetry server.
+ */
+ export interface ReplacementOption {
+
+	/**
+	 * A regular expression matching any property to be removed or replaced from the telemetry server.
+	 */
+	lookup: RegExp;
+
+	/**
+	 * The replacement value for the property. If not present or undefined, the property will be removed.
+	 */
+	replacementString?: string;
+}
+
 export class BaseTelemetryReporter {
 	private firstParty = false;
 	private userOptIn = false;

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------*/
 
 import * as vscode from "vscode";
+import { ReplacementOption } from "./baseTelemetryReporter";
 
 export const enum TelemetryLevel {
 	ON = "on",
@@ -33,5 +34,19 @@ export function getTelemetryLevel(): TelemetryLevel {
 		const config = vscode.workspace.getConfiguration(TELEMETRY_CONFIG_ID);
 		const enabled = config.get<boolean>(TELEMETRY_CONFIG_ENABLED_ID);
 		return enabled ? TelemetryLevel.ON : TelemetryLevel.OFF;
+	}
+}
+
+export function applyReplacements(data: Record<string, any>, replacementOptions: ReplacementOption[]) {
+	for (const key of Object.keys(data)) {
+		for (const option of replacementOptions) {
+			if (option.lookup.test(key)) {
+				if (option.replacementString !== undefined) {
+					data[key] = option.replacementString;
+				} else {
+					delete data[key];
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
For node application insights clients, there is a new constructor
parameter that allows users to pass a list of replacement options.

Each option includes a lookup regular expression and a replacement
string.

For each key in the base data or the envelope that matches the
lookup, the value will be replaced with the associated string. If
the value is undefined, then the key will be deleted.

Note that this only adds replacements for node clients as I did not
see an easy way to implement the same in web clients.

Fixes https://github.com/microsoft/vscode-extension-telemetry/issues/55

I have tested this in my own application and it is behaving as expected. However, I do not know how to regenerate the typings appropriately. Also, I still need to update some documentation to describe the new behaviour.