### PR TITLE
Fix Application Insights Guide's URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This module provides a consistent way for extensions to report telemetry
 over Application Insights. The module respects the user's decision about whether or
 not to send telemetry data.
 
-Follow [guide to set up Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/nodejs) in Azure and get your key.
+Follow [guide to set up Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource) in Azure and get your key.
 
 # Install
 `npm install @vscode/extension-telemetry`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This module provides a consistent way for extensions to report telemetry
 over Application Insights. The module respects the user's decision about whether or
 not to send telemetry data.
 
-Follow [guide to set up Application Insights](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-nodejs-quick-start) in Azure and get your key.
+Follow [guide to set up Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/nodejs) in Azure and get your key.
 
 # Install
 `npm install @vscode/extension-telemetry`


### PR DESCRIPTION
I noticed the URL for the Application Insights guide at the top of the README was pointing to https://docs.microsoft.com/en-us/azure/application-insights/app-insights-nodejs-quick-start which doesn't seem to exist anymore, and would therefore redirect to https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core which made it very confusing to figure out what steps to take.