### PR TITLE
Fix missing extension name in latest package.

### DIFF
--- a/src/common/baseTelemetryReporter.ts
+++ b/src/common/baseTelemetryReporter.ts
@@ -378,6 +378,7 @@ export class BaseTelemetryReporter {
 				});
 				properties = this.removePropertiesWithPossibleUserInfo(cleanProperties);
 			}
+			eventName = `${this.extensionId}/${eventName}`;
 			this.telemetryAppender.logEvent(eventName, { properties, measurements });
 		}
 	}


### PR DESCRIPTION
A large refactor of the way sending telemetry events worked led to the loss of the extension prefix when sending an error event. 

This fixes #104