### PR TITLE
Remove first party support of AI

### DIFF
--- a/.esbuild.config.js
+++ b/.esbuild.config.js
@@ -1,22 +1,11 @@
 const esbuild = require('esbuild');
-const fs = require('fs');
-const path = require('path');
-
-// Removes the warning from the app insights module since we don't want it to spam the console
-function patchAppInsightsModules() {
-	const nodeAppInsightsModule = fs.readFileSync(path.join(__dirname, 'node_modules/applicationinsights/out/Library/Config.js'), 'utf8');
-	const fileWithRemovedWarning = nodeAppInsightsModule.replace(/Logging.warn\([^)]*invalid instrumentation key[^)]*\)/, '// Warning removed');
-	fs.writeFileSync(path.join(__dirname, 'node_modules/applicationinsights/out/Library/Config.js'), fileWithRemovedWarning, 'utf8');
-}
-
-patchAppInsightsModules();
 
 // Build node packages and their minifed versions
 esbuild.build({
 	entryPoints: ['src/node/telemetryReporter.ts'],
 	tsconfig: "./src/node/tsconfig.json",
 	bundle: true,
-	external: ['vscode', '@microsoft/1ds-core-js', '@microsoft/1ds-post-js'],
+	external: ['vscode', './node_modules/*'],
 	sourcemap: true,
 	platform: 'node',
 	target: ['node14'],
@@ -28,7 +17,7 @@ esbuild.build({
 	tsconfig: "./src/node/tsconfig.json",
 	bundle: true,
 	sourcemap: false,
-	external: ['vscode', '@microsoft/1ds-core-js', '@microsoft/1ds-post-js'],
+	external: ['vscode', './node_modules/*'],
 	minify: true,
 	platform: 'node',
 	target: ['node14'],
@@ -42,7 +31,7 @@ esbuild.build({
 	tsconfig: "./src/browser/tsconfig.json",
 	bundle: true,
 	sourcemap: true,
-	external: ['vscode', '@microsoft/1ds-core-js', '@microsoft/1ds-post-js'],
+	external: ['vscode', './node_modules/*'],
 	platform: 'browser',
 	target: ['es6'],
 	outfile: 'lib/telemetryReporter.web.js',
@@ -54,7 +43,7 @@ esbuild.build({
 	format: "esm",
 	bundle: true,
 	sourcemap: false,
-	external: ['vscode', '@microsoft/1ds-core-js', '@microsoft/1ds-post-js'],
+	external: ['vscode', './node_modules/*'],
 	minify: true,
 	platform: 'browser',
 	target: ['es6'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "^3.2.3",
-        "@microsoft/1ds-post-js": "^3.2.3"
+        "@microsoft/1ds-core-js": "^3.2.4",
+        "@microsoft/1ds-post-js": "^3.2.4",
+        "@microsoft/applicationinsights-web": "^2.8.5",
+        "applicationinsights": "2.3.3"
       },
       "devDependencies": {
-        "@microsoft/applicationinsights-web": "^2.6.4",
         "@types/mocha": "^9.1.1",
         "@types/node": "^16.11.32",
         "@types/sinon": "^10.0.11",
         "@types/vscode": "^1.60.0",
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
-        "applicationinsights": "2.1.4",
         "esbuild": "^0.14.32",
         "eslint": "^8.12.0",
         "mocha": "^9.2.2",
@@ -32,34 +32,25 @@
       }
     },
     "node_modules/@azure/abort-controller": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
-      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/abort-controller/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
-    },
-    "node_modules/@azure/core-asynciterator-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
-      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@azure/core-auth": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
       "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
-      "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "tslib": "^2.2.0"
@@ -69,26 +60,23 @@
       }
     },
     "node_modules/@azure/core-auth/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@azure/core-http": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.1.tgz",
-      "integrity": "sha512-7ATnV3OGzCO2K9kMrh3NKUM8b4v+xasmlUhkNZz6uMbm+8XH/AexLkhRGsoo0GyKNlEGvyGEfytqTk0nUY2I4A==",
-      "dev": true,
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.5.tgz",
+      "integrity": "sha512-kctMqSQ6zfnlFpuYzfUKadeTyOQYbIQ+3Rj7dzVC3Dk1dOnHroTwR9hLYKX8/n85iJpkyaksaXpuh5L7GJRYuQ==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-asynciterator-polyfill": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-tracing": "1.0.0-preview.13",
         "@azure/logger": "^1.0.0",
         "@types/node-fetch": "^2.5.0",
         "@types/tunnel": "^0.0.3",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.7",
         "process": "^0.11.10",
         "tough-cookie": "^4.0.0",
         "tslib": "^2.2.0",
@@ -101,16 +89,14 @@
       }
     },
     "node_modules/@azure/core-http/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@azure/core-tracing": {
       "version": "1.0.0-preview.13",
       "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
       "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-      "dev": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.1",
         "tslib": "^2.2.0"
@@ -120,16 +106,14 @@
       }
     },
     "node_modules/@azure/core-tracing/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@azure/logger": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
       "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -138,10 +122,9 @@
       }
     },
     "node_modules/@azure/logger/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.1",
@@ -184,19 +167,70 @@
       "dev": true
     },
     "node_modules/@microsoft/1ds-core-js": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.3.tgz",
-      "integrity": "sha512-796A8fd90oUKDRO7UXUT9BwZ3G+a9XzJj5v012FcCN/2qRhEsIV3x/0wkx2S08T4FiQEUPkB2uoYHpEjEneM7g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.4.tgz",
+      "integrity": "sha512-ZkbCb63JF7hN+YQ8e/4nRe6vAIBMpoF8PQNiYiXSzYtdhXZ/pM3jB9/7g0O5LR4h/2IU1amAq0kpBgPbd6NWqg==",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.8.4",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
         "@microsoft/applicationinsights-shims": "^2.0.1",
         "@microsoft/dynamicproto-js": "^1.1.6"
       }
     },
-    "node_modules/@microsoft/1ds-core-js/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.4.tgz",
-      "integrity": "sha512-FoA0FNOsFbJnLyTyQlYs6+HR7HMEa6nAOE6WOm9WVejBHMHQ/Bdb+hfVFi6slxwCimr/ner90jchi4/sIYdnyQ==",
+    "node_modules/@microsoft/1ds-post-js": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.4.tgz",
+      "integrity": "sha512-SblhGNkd8C6kzewq+Gc/ViN2oYp1/TJFw0Y4rOfHXCr6siznInBggm5ehqZd/QPXh/7MYqCx4Gpw9Rra18fO0g==",
+      "dependencies": {
+        "@microsoft/1ds-core-js": "3.2.4",
+        "@microsoft/applicationinsights-shims": "^2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-analytics-js": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.8.5.tgz",
+      "integrity": "sha512-wlAUuTuONFfX6V0bPGH8FkN0DJUvcQD4KMyaw1DYTdVWg1Lsv7OewsfEIQBm8OS9phv7ALzMt0tEY3mNp3dtEQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.5.tgz",
+      "integrity": "sha512-jiK1lzgrn8PnRvhwDSUQQWZgGrywuvQOq/HbVFI6jdK9qqV7u+ndwFc4GbsTZQdNoWZLmcY8W1qjos8VX0+Zww==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.5.tgz",
+      "integrity": "sha512-oiGyz+4Bg+92RuvZn/1GrSwczhbyGrKyuVi/CExQjPKeqAm3ib2Uvlo0gZEm26AsSq0qPklG7H7n5s3y/krXhw==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.5.tgz",
+      "integrity": "sha512-7/EgK6r8GiDVluo84skCMNthgnPa6P7TXiJqHBJbuCf11N4YqkZoGjKs+Fo7h6XIPuYMUHVMNLpBObI7oS7HsQ==",
       "dependencies": {
         "@microsoft/applicationinsights-shims": "2.0.1",
         "@microsoft/dynamicproto-js": "^1.1.6"
@@ -205,115 +239,55 @@
         "tslib": "*"
       }
     },
-    "node_modules/@microsoft/1ds-core-js/node_modules/@microsoft/applicationinsights-shims": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
-      "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
-    },
-    "node_modules/@microsoft/1ds-post-js": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.3.tgz",
-      "integrity": "sha512-tcGJQXXr2LYoBbIXPoUVe1KCF3OtBsuKDFL7BXfmNtuSGtWF0yejm6H83DrR8/cUIGMRMUP9lqNlqFGwDYiwAQ==",
-      "dependencies": {
-        "@microsoft/1ds-core-js": "3.2.3",
-        "@microsoft/applicationinsights-shims": "^2.0.1",
-        "@microsoft/dynamicproto-js": "^1.1.6"
-      }
-    },
-    "node_modules/@microsoft/1ds-post-js/node_modules/@microsoft/applicationinsights-shims": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
-      "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
-    },
-    "node_modules/@microsoft/applicationinsights-analytics-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.6.4.tgz",
-      "integrity": "sha512-BHx3U6H4j3ddtl2wSJNt+kX2jG+qsvH4mNnimFJjZ4Mq9dheD3o6ghnBH8gQjIb5Up09JdyV5itsTZf1aC84Dg==",
-      "dev": true,
-      "dependencies": {
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.6.4.tgz",
-      "integrity": "sha512-ps9ZglUw8nzou9/CxmfRgHO7aGjhopu9YqsadbQL6yz/q8LSj1w30+ADa3gSMYCEEy8FQrDo5e5UebDEnX/w+A==",
-      "dev": true,
-      "dependencies": {
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-common": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.6.4.tgz",
-      "integrity": "sha512-/YLrKpxXL8zusjzu8GTYPuRrKw0OzUD4rLh8mxSlUZWK+SLOE/1loizJIesmd6OLgcgmOTrd1iZFVsuxn20b/g==",
-      "dev": true,
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.6.4.tgz",
-      "integrity": "sha512-rYxfJzl4aLXFGOLsRoJqyKj5qfhQTz1u/eXSo6N6gIIr/D+RCVNJZKVzeBh3xOOytm4UBGRshK0QFZJlIQL3Kw==",
-      "dev": true,
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
-      }
-    },
     "node_modules/@microsoft/applicationinsights-dependencies-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.6.4.tgz",
-      "integrity": "sha512-mJ/yTe00HPlUpQCmQWGhY3ronlkhsPgIYBWjxstN4NHRO4Qt17/ITxFoRa+r50J8Sf4ouc4qBoEFSVc56x80bg==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.8.5.tgz",
+      "integrity": "sha512-UwOpIxZjv3l8KtgrPd5WEmuvaXty3yTc/S279t7hSjxqOk+LDg0Q2dxap80EuQ5qHoGW32qhVkv+nHaASLoRkg==",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
       }
     },
     "node_modules/@microsoft/applicationinsights-properties-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.6.4.tgz",
-      "integrity": "sha512-SdIR3gVX46N0RdC0zV/pXKoCxwT+2+79ek6hVXvXa2o2I+JfgYEAxb1Q8flYNGEdlFd/Ge7BHcJLqFvjat1t4Q==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.8.5.tgz",
+      "integrity": "sha512-qlG17DPns2WPW2eL3gYR9mMe+I4Ro2Sp21VRELuVyRH+htkIoeCXcVWn8UPIGO3YonK3DU8mkN9cEx6ov9Aw+Q==",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
       }
     },
     "node_modules/@microsoft/applicationinsights-shims": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.0.tgz",
-      "integrity": "sha512-OaKew7f7acuNFgKYjMSPrRTRQi93xUyONWeeCeBlJSx7oRNJaL0TqbTvW6j5GHnSr3mhinPtAQ+rCQWASBnOrg==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
+      "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
     },
     "node_modules/@microsoft/applicationinsights-web": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.6.4.tgz",
-      "integrity": "sha512-/lBngt78Q7YNs8Llu1xz22f9oT5Rr2lo1QmSSSSKal30HL6kkzkP14J2E6+0+O5dRmyTDgOSiEePt6AhF8NFzg==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.8.5.tgz",
+      "integrity": "sha512-smgLYbDxiV8qmJOfvSL8FhcqXCXnOMJANcyc6FxL6TVn3ZqepG8r+ekV+b4iYn7vBcAc7XLU+zIEAuFC9IV0kA==",
       "dependencies": {
-        "@microsoft/applicationinsights-analytics-js": "2.6.4",
-        "@microsoft/applicationinsights-channel-js": "2.6.4",
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-dependencies-js": "2.6.4",
-        "@microsoft/applicationinsights-properties-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-analytics-js": "2.8.5",
+        "@microsoft/applicationinsights-channel-js": "2.8.5",
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-dependencies-js": "2.8.5",
+        "@microsoft/applicationinsights-properties-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
+      },
+      "peerDependencies": {
+        "tslib": "*"
       }
     },
     "node_modules/@microsoft/dynamicproto-js": {
@@ -357,72 +331,64 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
-      "integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.23.0.tgz",
-      "integrity": "sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "0.23.0",
-        "semver": "^7.1.3"
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.5.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.23.0.tgz",
-      "integrity": "sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
+      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
       "dependencies": {
-        "@opentelemetry/core": "0.23.0",
-        "@opentelemetry/semantic-conventions": "0.23.0"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
+      "integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-      "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/tracing": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.23.0.tgz",
-      "integrity": "sha512-3vNLS55bE0CG1RBDz7+wAAKpLjbl8fhQKqM4MvTy/LYHSolgyM5BNutSb/TcA9LtWvkdI0djgFXxeRig1OFqoQ==",
-      "deprecated": "Package renamed to @opentelemetry/sdk-trace-base",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "0.23.0",
-        "@opentelemetry/resources": "0.23.0",
-        "@opentelemetry/semantic-conventions": "0.23.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
+        "node": ">=14"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -475,14 +441,12 @@
     "node_modules/@types/node": {
       "version": "16.11.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.32.tgz",
-      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA==",
-      "dev": true
+      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
-      "dev": true,
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -492,7 +456,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -521,7 +484,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.3.tgz",
       "integrity": "sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -800,21 +762,30 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.1.4.tgz",
-      "integrity": "sha512-5cMAyW7jwHvdrKk4KU9VD6GR4o5D458KbdmAKKRp9SP9UNuY4pQHJoX60EmE14IlCXbIJd9CWUPhF4xQpCcwoQ==",
-      "dev": true,
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.3.3.tgz",
+      "integrity": "sha512-Q4o6gexNhzukgmzzWYzXLa2gdJ6DhM+c35tw0lRNNjc/qldWxGHVxV65DMRYrQIp4vetLdCK7Pyd/dmEsGO4qA==",
       "dependencies": {
-        "@azure/core-http": "^2.0.0",
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/tracing": "^0.23.0",
+        "@azure/core-http": "^2.2.3",
+        "@opentelemetry/api": "^1.0.4",
+        "@opentelemetry/core": "^1.0.1",
+        "@opentelemetry/sdk-trace-base": "^1.0.1",
+        "@opentelemetry/semantic-conventions": "^1.0.1",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "1.0.0",
-        "diagnostic-channel-publishers": "1.0.1"
+        "diagnostic-channel": "1.1.0",
+        "diagnostic-channel-publishers": "1.0.5"
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "applicationinsights-native-metrics": "*"
+      },
+      "peerDependenciesMeta": {
+        "applicationinsights-native-metrics": {
+          "optional": true
+        }
       }
     },
     "node_modules/argparse": {
@@ -836,7 +807,6 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
       "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "dev": true,
       "dependencies": {
         "stack-chain": "^1.3.7"
       },
@@ -848,7 +818,6 @@
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
       "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dev": true,
       "dependencies": {
         "semver": "^5.3.0",
         "shimmer": "^1.1.0"
@@ -861,7 +830,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -869,8 +837,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1015,7 +982,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
       "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "dev": true,
       "dependencies": {
         "async-hook-jl": "^1.7.6",
         "emitter-listener": "^1.0.1",
@@ -1029,7 +995,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -1038,7 +1003,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1056,7 +1020,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dev": true,
       "dependencies": {
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
@@ -1114,26 +1077,23 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/diagnostic-channel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.0.0.tgz",
-      "integrity": "sha512-v7Clmg5HG9XwIhqgbBRfwFzwZhxjvESZ33uu1cgcCLkdb9ZxgtY78eAgQMEQ39UecQ//4K5W75iq6LFBtAQD8w==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
+      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
       "dependencies": {
         "semver": "^5.3.0"
       }
     },
     "node_modules/diagnostic-channel-publishers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.1.tgz",
-      "integrity": "sha512-9D6XicU15MLXVtYEaBc3q1Di/4ciUFMULApfBc8/RUUwBk7g16t7/aFKZF4Kt4B3aFBtCbsTYJRAMKCSFaYWDA==",
-      "dev": true,
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.5.tgz",
+      "integrity": "sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg==",
       "peerDependencies": {
         "diagnostic-channel": "*"
       }
@@ -1142,7 +1102,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -1184,7 +1143,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
       "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dev": true,
       "dependencies": {
         "shimmer": "^1.2.0"
       }
@@ -1888,7 +1846,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2267,21 +2224,19 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
-      "dev": true,
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
-      "dev": true,
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {
-        "mime-db": "1.50.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -2504,7 +2459,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2636,23 +2590,20 @@
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true,
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "engines": {
         "node": ">= 0.6.0"
       }
     },
     "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2785,8 +2736,7 @@
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/semver": {
       "version": "7.3.5",
@@ -2836,8 +2786,7 @@
     "node_modules/shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "dev": true
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/sinon": {
       "version": "13.0.2",
@@ -2869,8 +2818,7 @@
     "node_modules/stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
-      "dev": true
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2944,7 +2892,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -2957,8 +2904,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
       "version": "1.14.1",
@@ -2984,7 +2930,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -3039,7 +2984,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -3057,7 +3001,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3071,14 +3014,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3174,7 +3115,6 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
       "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -3187,7 +3127,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3249,61 +3188,49 @@
   },
   "dependencies": {
     "@azure/abort-controller": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
-      "integrity": "sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
-    },
-    "@azure/core-asynciterator-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
-      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==",
-      "dev": true
     },
     "@azure/core-auth": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.3.2.tgz",
       "integrity": "sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==",
-      "dev": true,
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "tslib": "^2.2.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@azure/core-http": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.1.tgz",
-      "integrity": "sha512-7ATnV3OGzCO2K9kMrh3NKUM8b4v+xasmlUhkNZz6uMbm+8XH/AexLkhRGsoo0GyKNlEGvyGEfytqTk0nUY2I4A==",
-      "dev": true,
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-2.2.5.tgz",
+      "integrity": "sha512-kctMqSQ6zfnlFpuYzfUKadeTyOQYbIQ+3Rj7dzVC3Dk1dOnHroTwR9hLYKX8/n85iJpkyaksaXpuh5L7GJRYuQ==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-asynciterator-polyfill": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-tracing": "1.0.0-preview.13",
         "@azure/logger": "^1.0.0",
         "@types/node-fetch": "^2.5.0",
         "@types/tunnel": "^0.0.3",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.7",
         "process": "^0.11.10",
         "tough-cookie": "^4.0.0",
         "tslib": "^2.2.0",
@@ -3313,10 +3240,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -3324,17 +3250,15 @@
       "version": "1.0.0-preview.13",
       "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
       "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
-      "dev": true,
       "requires": {
         "@opentelemetry/api": "^1.0.1",
         "tslib": "^2.2.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -3342,16 +3266,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
       "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
-      "dev": true,
       "requires": {
         "tslib": "^2.2.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -3390,137 +3312,106 @@
       "dev": true
     },
     "@microsoft/1ds-core-js": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.3.tgz",
-      "integrity": "sha512-796A8fd90oUKDRO7UXUT9BwZ3G+a9XzJj5v012FcCN/2qRhEsIV3x/0wkx2S08T4FiQEUPkB2uoYHpEjEneM7g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.4.tgz",
+      "integrity": "sha512-ZkbCb63JF7hN+YQ8e/4nRe6vAIBMpoF8PQNiYiXSzYtdhXZ/pM3jB9/7g0O5LR4h/2IU1amAq0kpBgPbd6NWqg==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "2.8.4",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
         "@microsoft/applicationinsights-shims": "^2.0.1",
         "@microsoft/dynamicproto-js": "^1.1.6"
-      },
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": {
-          "version": "2.8.4",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.4.tgz",
-          "integrity": "sha512-FoA0FNOsFbJnLyTyQlYs6+HR7HMEa6nAOE6WOm9WVejBHMHQ/Bdb+hfVFi6slxwCimr/ner90jchi4/sIYdnyQ==",
-          "requires": {
-            "@microsoft/applicationinsights-shims": "2.0.1",
-            "@microsoft/dynamicproto-js": "^1.1.6"
-          }
-        },
-        "@microsoft/applicationinsights-shims": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
-          "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
-        }
       }
     },
     "@microsoft/1ds-post-js": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.3.tgz",
-      "integrity": "sha512-tcGJQXXr2LYoBbIXPoUVe1KCF3OtBsuKDFL7BXfmNtuSGtWF0yejm6H83DrR8/cUIGMRMUP9lqNlqFGwDYiwAQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.4.tgz",
+      "integrity": "sha512-SblhGNkd8C6kzewq+Gc/ViN2oYp1/TJFw0Y4rOfHXCr6siznInBggm5ehqZd/QPXh/7MYqCx4Gpw9Rra18fO0g==",
       "requires": {
-        "@microsoft/1ds-core-js": "3.2.3",
+        "@microsoft/1ds-core-js": "3.2.4",
         "@microsoft/applicationinsights-shims": "^2.0.1",
         "@microsoft/dynamicproto-js": "^1.1.6"
-      },
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
-          "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
-        }
       }
     },
     "@microsoft/applicationinsights-analytics-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.6.4.tgz",
-      "integrity": "sha512-BHx3U6H4j3ddtl2wSJNt+kX2jG+qsvH4mNnimFJjZ4Mq9dheD3o6ghnBH8gQjIb5Up09JdyV5itsTZf1aC84Dg==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.8.5.tgz",
+      "integrity": "sha512-wlAUuTuONFfX6V0bPGH8FkN0DJUvcQD4KMyaw1DYTdVWg1Lsv7OewsfEIQBm8OS9phv7ALzMt0tEY3mNp3dtEQ==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
       }
     },
     "@microsoft/applicationinsights-channel-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.6.4.tgz",
-      "integrity": "sha512-ps9ZglUw8nzou9/CxmfRgHO7aGjhopu9YqsadbQL6yz/q8LSj1w30+ADa3gSMYCEEy8FQrDo5e5UebDEnX/w+A==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.5.tgz",
+      "integrity": "sha512-jiK1lzgrn8PnRvhwDSUQQWZgGrywuvQOq/HbVFI6jdK9qqV7u+ndwFc4GbsTZQdNoWZLmcY8W1qjos8VX0+Zww==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
       }
     },
     "@microsoft/applicationinsights-common": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.6.4.tgz",
-      "integrity": "sha512-/YLrKpxXL8zusjzu8GTYPuRrKw0OzUD4rLh8mxSlUZWK+SLOE/1loizJIesmd6OLgcgmOTrd1iZFVsuxn20b/g==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.5.tgz",
+      "integrity": "sha512-oiGyz+4Bg+92RuvZn/1GrSwczhbyGrKyuVi/CExQjPKeqAm3ib2Uvlo0gZEm26AsSq0qPklG7H7n5s3y/krXhw==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
       }
     },
     "@microsoft/applicationinsights-core-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.6.4.tgz",
-      "integrity": "sha512-rYxfJzl4aLXFGOLsRoJqyKj5qfhQTz1u/eXSo6N6gIIr/D+RCVNJZKVzeBh3xOOytm4UBGRshK0QFZJlIQL3Kw==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.5.tgz",
+      "integrity": "sha512-7/EgK6r8GiDVluo84skCMNthgnPa6P7TXiJqHBJbuCf11N4YqkZoGjKs+Fo7h6XIPuYMUHVMNLpBObI7oS7HsQ==",
       "requires": {
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
       }
     },
     "@microsoft/applicationinsights-dependencies-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.6.4.tgz",
-      "integrity": "sha512-mJ/yTe00HPlUpQCmQWGhY3ronlkhsPgIYBWjxstN4NHRO4Qt17/ITxFoRa+r50J8Sf4ouc4qBoEFSVc56x80bg==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.8.5.tgz",
+      "integrity": "sha512-UwOpIxZjv3l8KtgrPd5WEmuvaXty3yTc/S279t7hSjxqOk+LDg0Q2dxap80EuQ5qHoGW32qhVkv+nHaASLoRkg==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
       }
     },
     "@microsoft/applicationinsights-properties-js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.6.4.tgz",
-      "integrity": "sha512-SdIR3gVX46N0RdC0zV/pXKoCxwT+2+79ek6hVXvXa2o2I+JfgYEAxb1Q8flYNGEdlFd/Ge7BHcJLqFvjat1t4Q==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.8.5.tgz",
+      "integrity": "sha512-qlG17DPns2WPW2eL3gYR9mMe+I4Ro2Sp21VRELuVyRH+htkIoeCXcVWn8UPIGO3YonK3DU8mkN9cEx6ov9Aw+Q==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
       }
     },
     "@microsoft/applicationinsights-shims": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.0.tgz",
-      "integrity": "sha512-OaKew7f7acuNFgKYjMSPrRTRQi93xUyONWeeCeBlJSx7oRNJaL0TqbTvW6j5GHnSr3mhinPtAQ+rCQWASBnOrg==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.1.tgz",
+      "integrity": "sha512-G0MXf6R6HndRbDy9BbEj0zrLeuhwt2nsXk2zKtF0TnYo39KgYqhYC2ayIzKPTm2KAE+xzD7rgyLdZnrcRvt9WQ=="
     },
     "@microsoft/applicationinsights-web": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.6.4.tgz",
-      "integrity": "sha512-/lBngt78Q7YNs8Llu1xz22f9oT5Rr2lo1QmSSSSKal30HL6kkzkP14J2E6+0+O5dRmyTDgOSiEePt6AhF8NFzg==",
-      "dev": true,
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.8.5.tgz",
+      "integrity": "sha512-smgLYbDxiV8qmJOfvSL8FhcqXCXnOMJANcyc6FxL6TVn3ZqepG8r+ekV+b4iYn7vBcAc7XLU+zIEAuFC9IV0kA==",
       "requires": {
-        "@microsoft/applicationinsights-analytics-js": "2.6.4",
-        "@microsoft/applicationinsights-channel-js": "2.6.4",
-        "@microsoft/applicationinsights-common": "2.6.4",
-        "@microsoft/applicationinsights-core-js": "2.6.4",
-        "@microsoft/applicationinsights-dependencies-js": "2.6.4",
-        "@microsoft/applicationinsights-properties-js": "2.6.4",
-        "@microsoft/applicationinsights-shims": "2.0.0",
-        "@microsoft/dynamicproto-js": "^1.1.4"
+        "@microsoft/applicationinsights-analytics-js": "2.8.5",
+        "@microsoft/applicationinsights-channel-js": "2.8.5",
+        "@microsoft/applicationinsights-common": "2.8.5",
+        "@microsoft/applicationinsights-core-js": "2.8.5",
+        "@microsoft/applicationinsights-dependencies-js": "2.8.5",
+        "@microsoft/applicationinsights-properties-js": "2.8.5",
+        "@microsoft/applicationinsights-shims": "2.0.1",
+        "@microsoft/dynamicproto-js": "^1.1.6"
       }
     },
     "@microsoft/dynamicproto-js": {
@@ -3555,48 +3446,41 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
-      "integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
     },
     "@opentelemetry/core": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.23.0.tgz",
-      "integrity": "sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "0.23.0",
-        "semver": "^7.1.3"
+        "@opentelemetry/semantic-conventions": "1.4.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.23.0.tgz",
-      "integrity": "sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
+      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
       "requires": {
-        "@opentelemetry/core": "0.23.0",
-        "@opentelemetry/semantic-conventions": "0.23.0"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
+      "integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
+      "requires": {
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
-      "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
-      "dev": true
-    },
-    "@opentelemetry/tracing": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.23.0.tgz",
-      "integrity": "sha512-3vNLS55bE0CG1RBDz7+wAAKpLjbl8fhQKqM4MvTy/LYHSolgyM5BNutSb/TcA9LtWvkdI0djgFXxeRig1OFqoQ==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/core": "0.23.0",
-        "@opentelemetry/resources": "0.23.0",
-        "@opentelemetry/semantic-conventions": "0.23.0",
-        "lodash.merge": "^4.6.2"
-      }
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -3648,14 +3532,12 @@
     "@types/node": {
       "version": "16.11.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.32.tgz",
-      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA==",
-      "dev": true
+      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA=="
     },
     "@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
-      "dev": true,
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -3665,7 +3547,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
           "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -3693,7 +3574,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.3.tgz",
       "integrity": "sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3861,18 +3741,19 @@
       }
     },
     "applicationinsights": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.1.4.tgz",
-      "integrity": "sha512-5cMAyW7jwHvdrKk4KU9VD6GR4o5D458KbdmAKKRp9SP9UNuY4pQHJoX60EmE14IlCXbIJd9CWUPhF4xQpCcwoQ==",
-      "dev": true,
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.3.3.tgz",
+      "integrity": "sha512-Q4o6gexNhzukgmzzWYzXLa2gdJ6DhM+c35tw0lRNNjc/qldWxGHVxV65DMRYrQIp4vetLdCK7Pyd/dmEsGO4qA==",
       "requires": {
-        "@azure/core-http": "^2.0.0",
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/tracing": "^0.23.0",
+        "@azure/core-http": "^2.2.3",
+        "@opentelemetry/api": "^1.0.4",
+        "@opentelemetry/core": "^1.0.1",
+        "@opentelemetry/sdk-trace-base": "^1.0.1",
+        "@opentelemetry/semantic-conventions": "^1.0.1",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "1.0.0",
-        "diagnostic-channel-publishers": "1.0.1"
+        "diagnostic-channel": "1.1.0",
+        "diagnostic-channel-publishers": "1.0.5"
       }
     },
     "argparse": {
@@ -3891,7 +3772,6 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
       "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "dev": true,
       "requires": {
         "stack-chain": "^1.3.7"
       }
@@ -3900,7 +3780,6 @@
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
       "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dev": true,
       "requires": {
         "semver": "^5.3.0",
         "shimmer": "^1.1.0"
@@ -3909,16 +3788,14 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -4030,7 +3907,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
       "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "dev": true,
       "requires": {
         "async-hook-jl": "^1.7.6",
         "emitter-listener": "^1.0.1",
@@ -4040,8 +3916,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -4049,7 +3924,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4064,7 +3938,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dev": true,
       "requires": {
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
@@ -4105,14 +3978,12 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "diagnostic-channel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.0.0.tgz",
-      "integrity": "sha512-v7Clmg5HG9XwIhqgbBRfwFzwZhxjvESZ33uu1cgcCLkdb9ZxgtY78eAgQMEQ39UecQ//4K5W75iq6LFBtAQD8w==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
+      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
       "requires": {
         "semver": "^5.3.0"
       },
@@ -4120,16 +3991,14 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.1.tgz",
-      "integrity": "sha512-9D6XicU15MLXVtYEaBc3q1Di/4ciUFMULApfBc8/RUUwBk7g16t7/aFKZF4Kt4B3aFBtCbsTYJRAMKCSFaYWDA==",
-      "dev": true,
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.5.tgz",
+      "integrity": "sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg==",
       "requires": {}
     },
     "diff": {
@@ -4160,7 +4029,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
       "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dev": true,
       "requires": {
         "shimmer": "^1.2.0"
       }
@@ -4601,7 +4469,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4880,18 +4747,16 @@
       }
     },
     "mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
-      "dev": true
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
-      "dev": true,
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "mime-db": "1.50.0"
+        "mime-db": "1.52.0"
       }
     },
     "minimatch": {
@@ -5054,7 +4919,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -5145,20 +5009,17 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -5235,8 +5096,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "7.3.5",
@@ -5274,8 +5134,7 @@
     "shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "dev": true
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "sinon": {
       "version": "13.0.2",
@@ -5300,8 +5159,7 @@
     "stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
-      "dev": true
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "string-width": {
       "version": "4.2.3",
@@ -5357,7 +5215,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -5367,8 +5224,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib": {
       "version": "1.14.1",
@@ -5387,8 +5243,7 @@
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -5420,8 +5275,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -5435,8 +5289,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -5447,14 +5300,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5528,7 +5379,6 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
       "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -5537,8 +5387,7 @@
     "xmlbuilder": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "compile": "tsc -noEmit -p 'src/browser/tsconfig.json' && tsc -noEmit -p 'src/node/tsconfig.json' && npm run build"
   },
   "dependencies": {
-    "@microsoft/1ds-core-js": "^3.2.3",
-    "@microsoft/1ds-post-js": "^3.2.3",
-    "@microsoft/applicationinsights-web": "^2.6.4",
-    "applicationinsights": "2.1.4"
+    "@microsoft/1ds-core-js": "^3.2.4",
+    "@microsoft/1ds-post-js": "^3.2.4",
+    "@microsoft/applicationinsights-web": "^2.8.5",
+    "applicationinsights": "2.3.3"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -19,17 +19,17 @@
   },
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.3",
-    "@microsoft/1ds-post-js": "^3.2.3"
+    "@microsoft/1ds-post-js": "^3.2.3",
+    "@microsoft/applicationinsights-web": "^2.6.4",
+    "applicationinsights": "2.1.4"
   },
   "devDependencies": {
-    "@microsoft/applicationinsights-web": "^2.6.4",
     "@types/mocha": "^9.1.1",
     "@types/node": "^16.11.32",
     "@types/sinon": "^10.0.11",
     "@types/vscode": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
-    "applicationinsights": "2.1.4",
     "esbuild": "^0.14.32",
     "eslint": "^8.12.0",
     "mocha": "^9.2.2",

--- a/src/node/telemetryReporter.ts
+++ b/src/node/telemetryReporter.ts
@@ -49,10 +49,6 @@ const appInsightsClientFactory = async (key: string, replacementOptions?: Replac
 			appInsightsClient.context.tags[appInsightsClient.context.keys.cloudRole] = vscode.env.appName;
 			appInsightsClient.context.tags[appInsightsClient.context.keys.cloudRoleInstance] = vscode.env.appName;
 		}
-		//check if it's an Asimov key to change the endpoint
-		if (key && key.indexOf("AIF-") === 0) {
-			appInsightsClient.config.endpointUrl = "https://mobile.events.data.microsoft.com/collect/v1";
-		}
 	} catch (e: any) {
 		return Promise.reject("Failed to initialize app insights!\n" + e.message);
 	}
@@ -167,8 +163,11 @@ export default class TelemetryReporter extends BaseTelemetryReporter {
 		}
 
 		const appender = new BaseTelemetryAppender(key, clientFactory);
-		// If it's a specialized AIF app insights key or a 1DS key then it is first party
-		if (key && (key.indexOf("AIF-") === 0 || TelemetryUtil.shouldUseOneDataSystemSDK(key))) {
+		if (key && key.indexOf("AIF-") === 0) {
+			throw new Error("AIF keys are no longer supported. Please switch to 1DS keys for 1st party extensions");
+		}
+		// 1DS is always first party
+		if (TelemetryUtil.shouldUseOneDataSystemSDK(key)) {
 			firstParty = true;
 		}
 		super(extensionId, extensionVersion, appender, {


### PR DESCRIPTION
First party extensions should no longer use App Insights.

1. This now throws a warning when AIF keys are used

2. We now do not bundle any node modules together and instead just bundle the source code