### PR TITLE
Skip pre-publish approval

### DIFF
--- a/build/azure-pipelines/pipeline.yml
+++ b/build/azure-pipelines/pipeline.yml
@@ -43,4 +43,5 @@ extends:
           - script: npm run test
             displayName: Test npm package
 
+        publishRequiresApproval: false
         publishPackage: ${{ parameters.publishPackage }}


### PR DESCRIPTION
The package is smoke tested locally and therefore no need to get another approval prior to publishing.