### PR TITLE
Ignore a few more unnecessary files in the bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,5 @@ tsfmt.json
 *.tgz
 *.test.ts
 dist/test
+injectVersion.js
+*.proposed.*.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/extension-telemetry",
-  "version": "0.7.1-preview",
+  "version": "0.7.2-preview",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/extension-telemetry",
-      "version": "0.7.1-preview",
+      "version": "0.7.2-preview",
       "license": "MIT",
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vscode/extension-telemetry",
   "description": "A module for Visual Studio Code extensions to report consistent telemetry.",
-  "version": "0.7.1-preview",
+  "version": "0.7.2-preview",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
We can ignore the proposed.d.ts and the prepack script after it's packaged.