### PR TITLE
Removes the ability to log a raw exception from the module

### DIFF
--- a/dist/telemetryReporter.d.ts
+++ b/dist/telemetryReporter.d.ts
@@ -92,23 +92,6 @@ export default class TelemetryReporter {
 	sendDangerousTelemetryErrorEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
 
 	/**
-	 * Sends an exception which includes the error stack, properties, and measurements
-	 * @param error The error to send
-	 * @param properties The set of properties to add to the event in the form of a string key value pair
-	 * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
-	 */
-	sendTelemetryException(error: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
-
-	/**
-	 * **DANGEROUS** Given an error, properties, and measurements. Sends an exception event without checking the telemetry setting
-	 * Do not use unless in a controlled environment i.e. sending telmetry from a CI pipeline or testing during development
-	 * @param eventName The name of the event
-	 * @param properties The properties to send with the event
-	 * @param measurements The measurements (numeric values) to send with the event
-	 */
-	sendDangerousTelemetryException(error: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void
-
-	/**
 	 * Disposes of the telemetry reporter. This flushes the remaining events and disposes of the telemetry client.
 	 */
 	dispose(): Promise<any>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@vscode/extension-telemetry",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/extension-telemetry",
-      "version": "0.7.7",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "^3.2.9",
-        "@microsoft/1ds-post-js": "^3.2.9",
-        "@microsoft/applicationinsights-web-basic": "^2.8.11",
-        "applicationinsights": "2.5.0"
+        "@microsoft/1ds-core-js": "^3.2.10",
+        "@microsoft/1ds-post-js": "^3.2.10",
+        "@microsoft/applicationinsights-web-basic": "^3.0.0",
+        "applicationinsights": "2.6.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
@@ -106,15 +106,15 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@azure/core-util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.1.1.tgz",
-      "integrity": "sha512-A4TBYVQCtHOigFb2ETiiKFDocBoI1Zk2Ui1KpI42aJSIDexF7DHQFpnjonltXAIU/ceH+1fsZAWWgvX6/AKzog==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
+      "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@azure/core-util/node_modules/tslib": {
@@ -134,6 +134,27 @@
       }
     },
     "node_modules/@azure/logger/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.3.tgz",
+      "integrity": "sha512-9dvTQQ9OhjX0uh4PtDEMPGTP3WihTVLi+DHL9jRMQMPf0trYEbb8ZRIQNo+1JqchkR1YkBDBkki5hJstpUprtA==",
+      "dependencies": {
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^1.4.0",
+        "@opentelemetry/core": "^1.9.0",
+        "@opentelemetry/instrumentation": "^0.35.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@azure/opentelemetry-instrumentation-azure-sdk/node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
@@ -179,87 +200,128 @@
       "dev": true
     },
     "node_modules/@microsoft/1ds-core-js": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.9.tgz",
-      "integrity": "sha512-3pCfM2TzHn3gU9pxHztduKcVRdb/nzruvPFfHPZD0IM0mb0h6TGo2isELF3CTMahTx50RAC51ojNIw2/7VRkOg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.10.tgz",
+      "integrity": "sha512-fYzgrVuAK6HH66QJq5gyB+hmql2OTWwvP2520B7vM/idl8+O0yV9/PPTuwTpCWzGcksq5X3LaUX2MugzaRHLHA==",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.8.10",
+        "@microsoft/applicationinsights-core-js": "2.8.12",
         "@microsoft/applicationinsights-shims": "^2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.7"
       }
     },
     "node_modules/@microsoft/1ds-post-js": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.9.tgz",
-      "integrity": "sha512-D/RtqkQ2Nr4cuoGqmhi5QTmi3cBlxehIThJ1u3BaH9H/YkLNTKEcHZRWTXy14bXheCefNHciLuadg37G2Kekcg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.10.tgz",
+      "integrity": "sha512-/yUdt1wUQpB0jM3LGwgrkSX2TLc3geHj4RflYYmW20uHN9XDqjSQfPiTm5m1sMcISz7OdQQd/PeqYnybkBOMfQ==",
       "dependencies": {
-        "@microsoft/1ds-core-js": "3.2.9",
+        "@microsoft/1ds-core-js": "3.2.10",
         "@microsoft/applicationinsights-shims": "^2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.7"
       }
     },
     "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.11.tgz",
-      "integrity": "sha512-DGDNzT4DMlSvUzWjA4y3tDg47+QYOPV+W07vlfdPwGgLwrl4n6Q4crrW8Y/IOpthHAKDU8rolSAUvP3NqxPi4Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.0.tgz",
+      "integrity": "sha512-5L8jgqsy8H2jB4sSy1giJ6BeNE6c3qqkQBfRs/G0jgg7B/6dimLABCI72nOOgae3irrfxrnPX9EXz50YbG4XZQ==",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "2.8.11",
-        "@microsoft/applicationinsights-core-js": "2.8.11",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-common": "3.0.0",
+        "@microsoft/applicationinsights-core-js": "3.0.0",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
       }
     },
     "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.11.tgz",
-      "integrity": "sha512-6ScXplyb9Zb0K6TQRfqStm20j5lIe/Dslf65ozows6ibDcKkWl2ZdqzFhymVJZz1WRNpSyD4aA8qnqmslIER6g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.0.tgz",
+      "integrity": "sha512-ZgN3So3aNmhHLkViZoYqzYehlYhdM1iB5svoAzB0IUnR2s6wvBEZ4SYpW5WimK0hvAcOQiRG67KFMC1eI4kA0Q==",
       "dependencies": {
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
       }
     },
-    "node_modules/@microsoft/applicationinsights-common": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.11.tgz",
-      "integrity": "sha512-Cxu4gRajkYv9buEtrcLGHK97AqGK62feN9jH9/JSjUSiSFhbnWtYvEg1EMqMI/P4pneu53yLJloITB+TKwmK7A==",
+    "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.8.11",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js/node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+      "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.0.tgz",
+      "integrity": "sha512-8oAFm0Q1hmsv2StpLy3RboTMHhuk5/QrrBHiECCbzyL8vAd+Y3qHbPdN9lLPjvwLezAp6o2Ej8mZpR2Q3JsYlQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.0.0",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
       }
     },
     "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.11.tgz",
-      "integrity": "sha512-6ScXplyb9Zb0K6TQRfqStm20j5lIe/Dslf65ozows6ibDcKkWl2ZdqzFhymVJZz1WRNpSyD4aA8qnqmslIER6g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.0.tgz",
+      "integrity": "sha512-ZgN3So3aNmhHLkViZoYqzYehlYhdM1iB5svoAzB0IUnR2s6wvBEZ4SYpW5WimK0hvAcOQiRG67KFMC1eI4kA0Q==",
       "dependencies": {
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
       }
     },
+    "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common/node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+      "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
     "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.10.tgz",
-      "integrity": "sha512-jQrufDW0+sV8fBhRvzIPNGiCC6dELH+Ug0DM5CfN9757TBqZJz8CSWyDjex39as8+jD0F/8HRU9QdmrVgq5vFg==",
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.12.tgz",
+      "integrity": "sha512-lA4epwWPBJ4awx07QQVCkoxygsl0qiTNoSYaR63hRE56ybu4kpp3tpYo/AfOI1DZMgKB8H0EwDz4vVmzUT3p/A==",
       "dependencies": {
         "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/dynamicproto-js": "^1.1.9"
       },
       "peerDependencies": {
         "tslib": "*"
       }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js/node_modules/@microsoft/dynamicproto-js": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
+      "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@microsoft/applicationinsights-shims": {
       "version": "2.0.2",
@@ -267,30 +329,48 @@
       "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
     },
     "node_modules/@microsoft/applicationinsights-web-basic": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-2.8.11.tgz",
-      "integrity": "sha512-11T7bbP4ifIBg95E9mYZv1g/vcWvw/KaWKRcGMREP3+vBTLBwMB8r2e9Zd583bOVx+9/gRvfIg+Z/lInQqAfbA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.0.tgz",
+      "integrity": "sha512-bMIeVNGUh9EXDEUamkq3BRQbyEVjzbVSQJsrxlk+3N/lB3cYJ80MyLjrNCgyzgXzX6BKJ9v7TyqpY3KVxb9j2w==",
       "dependencies": {
-        "@microsoft/applicationinsights-channel-js": "2.8.11",
-        "@microsoft/applicationinsights-common": "2.8.11",
-        "@microsoft/applicationinsights-core-js": "2.8.11",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-channel-js": "3.0.0",
+        "@microsoft/applicationinsights-common": "3.0.0",
+        "@microsoft/applicationinsights-core-js": "3.0.0",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
       }
     },
     "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.11.tgz",
-      "integrity": "sha512-6ScXplyb9Zb0K6TQRfqStm20j5lIe/Dslf65ozows6ibDcKkWl2ZdqzFhymVJZz1WRNpSyD4aA8qnqmslIER6g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.0.tgz",
+      "integrity": "sha512-ZgN3So3aNmhHLkViZoYqzYehlYhdM1iB5svoAzB0IUnR2s6wvBEZ4SYpW5WimK0hvAcOQiRG67KFMC1eI4kA0Q==",
       "dependencies": {
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "peerDependencies": {
         "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web-basic/node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+      "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
@@ -302,6 +382,14 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.7.tgz",
       "integrity": "sha512-SK3D3aVt+5vOOccKPnGaJWB5gQ8FuKfjboUJHedMP7gu54HqSCXX5iFXhktGD8nfJb0Go30eDvs/UDoTnR2kOA=="
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.9.5.tgz",
+      "integrity": "sha512-hCUM1/HKLcHKWeTjX/ervVOp6eim+XEdFI3U7NUU+yec7XPQTxe4sDujPY5unlTQ2CHpxTewRo7mIyaRdMFlUw==",
+      "peerDependencies": {
+        "typescript": ">=1"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -339,62 +427,78 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
-      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-4DWYNb3dLs2mSCGl65jY3aEgbvPWSHVQV/dmDWiYeWUrMakZQFcymqZOSUNZO0uDrEJoxMu8O5tZktX6UKFwag==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.4.0"
+        "@opentelemetry/semantic-conventions": "1.12.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.35.1.tgz",
+      "integrity": "sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==",
+      "dependencies": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
-      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.12.0.tgz",
+      "integrity": "sha512-gunMKXG0hJrR0LXrqh7BVbziA/+iJBL3ZbXCXO64uY+SrExkwoyJkpiq9l5ismkGF/A20mDEV7tGwh+KyPw00Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.4.0",
-        "@opentelemetry/semantic-conventions": "1.4.0"
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/semantic-conventions": "1.12.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
-      "integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.12.0.tgz",
+      "integrity": "sha512-pfCOB3tNDlYVoWuz4D7Ji+Jmy9MHnATWHVpkERdCEiwUGEZ+4IvNPXUcPc37wJVmMpjGLeaWgPPrie0KIpWf1A==",
       "dependencies": {
-        "@opentelemetry/core": "1.4.0",
-        "@opentelemetry/resources": "1.4.0",
-        "@opentelemetry/semantic-conventions": "1.4.0"
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/resources": "1.12.0",
+        "@opentelemetry/semantic-conventions": "1.12.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
-      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.12.0.tgz",
+      "integrity": "sha512-hO+bdeGOlJwqowUBoZF5LyP3ORUFOP1G0GRv8N45W/cztXbT2ZEXaAzfokRS9Xc9FWmYrDj32mF6SzH6wuoIyA==",
       "engines": {
         "node": ">=14"
       }
@@ -760,21 +864,23 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.5.0.tgz",
-      "integrity": "sha512-6kIFmpANRok+6FhCOmO7ZZ/mh7fdNKn17BaT13cg/RV5roLPJlA6q8srWexayHd3MPcwMb9072e8Zp0P47s/pw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.6.0.tgz",
+      "integrity": "sha512-ldeFvbocbRoMxS361lOwmLL3ltWfgNxALrttge6BrpsPMTStGzevoiqaWieIjZ/3qNmljOd+xmwaNPpBoefdmA==",
       "dependencies": {
         "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.10.0",
+        "@azure/core-rest-pipeline": "1.10.1",
+        "@azure/core-util": "1.2.0",
+        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.3",
         "@microsoft/applicationinsights-web-snippet": "^1.0.1",
         "@opentelemetry/api": "^1.0.4",
-        "@opentelemetry/core": "^1.0.1",
-        "@opentelemetry/sdk-trace-base": "^1.0.1",
-        "@opentelemetry/semantic-conventions": "^1.0.1",
+        "@opentelemetry/core": "^1.12.0",
+        "@opentelemetry/sdk-trace-base": "^1.12.0",
+        "@opentelemetry/semantic-conventions": "^1.12.0",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "1.1.0",
-        "diagnostic-channel-publishers": "1.0.5"
+        "diagnostic-channel-publishers": "1.0.6"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -1090,9 +1196,9 @@
       }
     },
     "node_modules/diagnostic-channel-publishers": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.5.tgz",
-      "integrity": "sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.6.tgz",
+      "integrity": "sha512-RE5AP4JmEm/CV06gOyFdgWWm3gMNOoXulod2mq4ysiz9s77ZhHb1P1DGrfePHjNOmgvWglhegmj5q8DNtjRrEg==",
       "peerDependencies": {
         "diagnostic-channel": "*"
       }
@@ -1519,6 +1625,11 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -1608,6 +1719,17 @@
       "dev": true,
       "engines": {
         "node": ">=4.x"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/has-flag": {
@@ -1713,6 +1835,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -1862,7 +1995,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2087,6 +2219,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2196,6 +2333,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -2307,6 +2449,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dependencies": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2374,7 +2545,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2502,6 +2672,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2577,7 +2758,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
       "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2713,8 +2893,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
@@ -2828,9 +3007,9 @@
       }
     },
     "@azure/core-util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.1.1.tgz",
-      "integrity": "sha512-A4TBYVQCtHOigFb2ETiiKFDocBoI1Zk2Ui1KpI42aJSIDexF7DHQFpnjonltXAIU/ceH+1fsZAWWgvX6/AKzog==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
+      "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "tslib": "^2.2.0"
@@ -2848,6 +3027,26 @@
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.3.tgz",
       "integrity": "sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==",
       "requires": {
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "@azure/opentelemetry-instrumentation-azure-sdk": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.3.tgz",
+      "integrity": "sha512-9dvTQQ9OhjX0uh4PtDEMPGTP3WihTVLi+DHL9jRMQMPf0trYEbb8ZRIQNo+1JqchkR1YkBDBkki5hJstpUprtA==",
+      "requires": {
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^1.4.0",
+        "@opentelemetry/core": "^1.9.0",
+        "@opentelemetry/instrumentation": "^0.35.0",
         "tslib": "^2.2.0"
       },
       "dependencies": {
@@ -2893,75 +3092,118 @@
       "dev": true
     },
     "@microsoft/1ds-core-js": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.9.tgz",
-      "integrity": "sha512-3pCfM2TzHn3gU9pxHztduKcVRdb/nzruvPFfHPZD0IM0mb0h6TGo2isELF3CTMahTx50RAC51ojNIw2/7VRkOg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.10.tgz",
+      "integrity": "sha512-fYzgrVuAK6HH66QJq5gyB+hmql2OTWwvP2520B7vM/idl8+O0yV9/PPTuwTpCWzGcksq5X3LaUX2MugzaRHLHA==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "2.8.10",
+        "@microsoft/applicationinsights-core-js": "2.8.12",
         "@microsoft/applicationinsights-shims": "^2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.7"
       }
     },
     "@microsoft/1ds-post-js": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.9.tgz",
-      "integrity": "sha512-D/RtqkQ2Nr4cuoGqmhi5QTmi3cBlxehIThJ1u3BaH9H/YkLNTKEcHZRWTXy14bXheCefNHciLuadg37G2Kekcg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.10.tgz",
+      "integrity": "sha512-/yUdt1wUQpB0jM3LGwgrkSX2TLc3geHj4RflYYmW20uHN9XDqjSQfPiTm5m1sMcISz7OdQQd/PeqYnybkBOMfQ==",
       "requires": {
-        "@microsoft/1ds-core-js": "3.2.9",
+        "@microsoft/1ds-core-js": "3.2.10",
         "@microsoft/applicationinsights-shims": "^2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.7"
       }
     },
     "@microsoft/applicationinsights-channel-js": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.11.tgz",
-      "integrity": "sha512-DGDNzT4DMlSvUzWjA4y3tDg47+QYOPV+W07vlfdPwGgLwrl4n6Q4crrW8Y/IOpthHAKDU8rolSAUvP3NqxPi4Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.0.tgz",
+      "integrity": "sha512-5L8jgqsy8H2jB4sSy1giJ6BeNE6c3qqkQBfRs/G0jgg7B/6dimLABCI72nOOgae3irrfxrnPX9EXz50YbG4XZQ==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.8.11",
-        "@microsoft/applicationinsights-core-js": "2.8.11",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-common": "3.0.0",
+        "@microsoft/applicationinsights-core-js": "3.0.0",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "dependencies": {
         "@microsoft/applicationinsights-core-js": {
-          "version": "2.8.11",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.11.tgz",
-          "integrity": "sha512-6ScXplyb9Zb0K6TQRfqStm20j5lIe/Dslf65ozows6ibDcKkWl2ZdqzFhymVJZz1WRNpSyD4aA8qnqmslIER6g==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.0.tgz",
+          "integrity": "sha512-ZgN3So3aNmhHLkViZoYqzYehlYhdM1iB5svoAzB0IUnR2s6wvBEZ4SYpW5WimK0hvAcOQiRG67KFMC1eI4kA0Q==",
           "requires": {
-            "@microsoft/applicationinsights-shims": "2.0.2",
-            "@microsoft/dynamicproto-js": "^1.1.7"
+            "@microsoft/applicationinsights-shims": "3.0.1",
+            "@microsoft/dynamicproto-js": "^2.0.2",
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+          }
+        },
+        "@microsoft/applicationinsights-shims": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+          "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+          "requires": {
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+          }
+        },
+        "@microsoft/dynamicproto-js": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+          "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+          "requires": {
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
           }
         }
       }
     },
     "@microsoft/applicationinsights-common": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.11.tgz",
-      "integrity": "sha512-Cxu4gRajkYv9buEtrcLGHK97AqGK62feN9jH9/JSjUSiSFhbnWtYvEg1EMqMI/P4pneu53yLJloITB+TKwmK7A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.0.tgz",
+      "integrity": "sha512-8oAFm0Q1hmsv2StpLy3RboTMHhuk5/QrrBHiECCbzyL8vAd+Y3qHbPdN9lLPjvwLezAp6o2Ej8mZpR2Q3JsYlQ==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "2.8.11",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-core-js": "3.0.0",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "dependencies": {
         "@microsoft/applicationinsights-core-js": {
-          "version": "2.8.11",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.11.tgz",
-          "integrity": "sha512-6ScXplyb9Zb0K6TQRfqStm20j5lIe/Dslf65ozows6ibDcKkWl2ZdqzFhymVJZz1WRNpSyD4aA8qnqmslIER6g==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.0.tgz",
+          "integrity": "sha512-ZgN3So3aNmhHLkViZoYqzYehlYhdM1iB5svoAzB0IUnR2s6wvBEZ4SYpW5WimK0hvAcOQiRG67KFMC1eI4kA0Q==",
           "requires": {
-            "@microsoft/applicationinsights-shims": "2.0.2",
-            "@microsoft/dynamicproto-js": "^1.1.7"
+            "@microsoft/applicationinsights-shims": "3.0.1",
+            "@microsoft/dynamicproto-js": "^2.0.2",
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+          }
+        },
+        "@microsoft/applicationinsights-shims": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+          "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+          "requires": {
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+          }
+        },
+        "@microsoft/dynamicproto-js": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+          "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+          "requires": {
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
           }
         }
       }
     },
     "@microsoft/applicationinsights-core-js": {
-      "version": "2.8.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.10.tgz",
-      "integrity": "sha512-jQrufDW0+sV8fBhRvzIPNGiCC6dELH+Ug0DM5CfN9757TBqZJz8CSWyDjex39as8+jD0F/8HRU9QdmrVgq5vFg==",
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.12.tgz",
+      "integrity": "sha512-lA4epwWPBJ4awx07QQVCkoxygsl0qiTNoSYaR63hRE56ybu4kpp3tpYo/AfOI1DZMgKB8H0EwDz4vVmzUT3p/A==",
       "requires": {
         "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/dynamicproto-js": "^1.1.9"
+      },
+      "dependencies": {
+        "@microsoft/dynamicproto-js": {
+          "version": "1.1.9",
+          "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.9.tgz",
+          "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
+        }
       }
     },
     "@microsoft/applicationinsights-shims": {
@@ -2970,24 +3212,42 @@
       "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
     },
     "@microsoft/applicationinsights-web-basic": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-2.8.11.tgz",
-      "integrity": "sha512-11T7bbP4ifIBg95E9mYZv1g/vcWvw/KaWKRcGMREP3+vBTLBwMB8r2e9Zd583bOVx+9/gRvfIg+Z/lInQqAfbA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.0.0.tgz",
+      "integrity": "sha512-bMIeVNGUh9EXDEUamkq3BRQbyEVjzbVSQJsrxlk+3N/lB3cYJ80MyLjrNCgyzgXzX6BKJ9v7TyqpY3KVxb9j2w==",
       "requires": {
-        "@microsoft/applicationinsights-channel-js": "2.8.11",
-        "@microsoft/applicationinsights-common": "2.8.11",
-        "@microsoft/applicationinsights-core-js": "2.8.11",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
+        "@microsoft/applicationinsights-channel-js": "3.0.0",
+        "@microsoft/applicationinsights-common": "3.0.0",
+        "@microsoft/applicationinsights-core-js": "3.0.0",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       },
       "dependencies": {
         "@microsoft/applicationinsights-core-js": {
-          "version": "2.8.11",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.11.tgz",
-          "integrity": "sha512-6ScXplyb9Zb0K6TQRfqStm20j5lIe/Dslf65ozows6ibDcKkWl2ZdqzFhymVJZz1WRNpSyD4aA8qnqmslIER6g==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.0.tgz",
+          "integrity": "sha512-ZgN3So3aNmhHLkViZoYqzYehlYhdM1iB5svoAzB0IUnR2s6wvBEZ4SYpW5WimK0hvAcOQiRG67KFMC1eI4kA0Q==",
           "requires": {
-            "@microsoft/applicationinsights-shims": "2.0.2",
-            "@microsoft/dynamicproto-js": "^1.1.7"
+            "@microsoft/applicationinsights-shims": "3.0.1",
+            "@microsoft/dynamicproto-js": "^2.0.2",
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+          }
+        },
+        "@microsoft/applicationinsights-shims": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+          "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+          "requires": {
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+          }
+        },
+        "@microsoft/dynamicproto-js": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+          "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+          "requires": {
+            "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
           }
         }
       }
@@ -3001,6 +3261,12 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.7.tgz",
       "integrity": "sha512-SK3D3aVt+5vOOccKPnGaJWB5gQ8FuKfjboUJHedMP7gu54HqSCXX5iFXhktGD8nfJb0Go30eDvs/UDoTnR2kOA=="
+    },
+    "@nevware21/ts-utils": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.9.5.tgz",
+      "integrity": "sha512-hCUM1/HKLcHKWeTjX/ervVOp6eim+XEdFI3U7NUU+yec7XPQTxe4sDujPY5unlTQ2CHpxTewRo7mIyaRdMFlUw==",
+      "requires": {}
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3029,41 +3295,51 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
-      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
     },
     "@opentelemetry/core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
-      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-4DWYNb3dLs2mSCGl65jY3aEgbvPWSHVQV/dmDWiYeWUrMakZQFcymqZOSUNZO0uDrEJoxMu8O5tZktX6UKFwag==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.4.0"
+        "@opentelemetry/semantic-conventions": "1.12.0"
+      }
+    },
+    "@opentelemetry/instrumentation": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.35.1.tgz",
+      "integrity": "sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==",
+      "requires": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
-      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.12.0.tgz",
+      "integrity": "sha512-gunMKXG0hJrR0LXrqh7BVbziA/+iJBL3ZbXCXO64uY+SrExkwoyJkpiq9l5ismkGF/A20mDEV7tGwh+KyPw00Q==",
       "requires": {
-        "@opentelemetry/core": "1.4.0",
-        "@opentelemetry/semantic-conventions": "1.4.0"
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/semantic-conventions": "1.12.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
-      "integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.12.0.tgz",
+      "integrity": "sha512-pfCOB3tNDlYVoWuz4D7Ji+Jmy9MHnATWHVpkERdCEiwUGEZ+4IvNPXUcPc37wJVmMpjGLeaWgPPrie0KIpWf1A==",
       "requires": {
-        "@opentelemetry/core": "1.4.0",
-        "@opentelemetry/resources": "1.4.0",
-        "@opentelemetry/semantic-conventions": "1.4.0"
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/resources": "1.12.0",
+        "@opentelemetry/semantic-conventions": "1.12.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
-      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.12.0.tgz",
+      "integrity": "sha512-hO+bdeGOlJwqowUBoZF5LyP3ORUFOP1G0GRv8N45W/cztXbT2ZEXaAzfokRS9Xc9FWmYrDj32mF6SzH6wuoIyA=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -3309,21 +3585,23 @@
       }
     },
     "applicationinsights": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.5.0.tgz",
-      "integrity": "sha512-6kIFmpANRok+6FhCOmO7ZZ/mh7fdNKn17BaT13cg/RV5roLPJlA6q8srWexayHd3MPcwMb9072e8Zp0P47s/pw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.6.0.tgz",
+      "integrity": "sha512-ldeFvbocbRoMxS361lOwmLL3ltWfgNxALrttge6BrpsPMTStGzevoiqaWieIjZ/3qNmljOd+xmwaNPpBoefdmA==",
       "requires": {
         "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.10.0",
+        "@azure/core-rest-pipeline": "1.10.1",
+        "@azure/core-util": "1.2.0",
+        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.3",
         "@microsoft/applicationinsights-web-snippet": "^1.0.1",
         "@opentelemetry/api": "^1.0.4",
-        "@opentelemetry/core": "^1.0.1",
-        "@opentelemetry/sdk-trace-base": "^1.0.1",
-        "@opentelemetry/semantic-conventions": "^1.0.1",
+        "@opentelemetry/core": "^1.12.0",
+        "@opentelemetry/sdk-trace-base": "^1.12.0",
+        "@opentelemetry/semantic-conventions": "^1.12.0",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "1.1.0",
-        "diagnostic-channel-publishers": "1.0.5"
+        "diagnostic-channel-publishers": "1.0.6"
       }
     },
     "argparse": {
@@ -3565,9 +3843,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.5.tgz",
-      "integrity": "sha512-dJwUS0915pkjjimPJVDnS/QQHsH0aOYhnZsLJdnZIMOrB+csj8RnZhWTuwnm8R5v3Z7OZs+ksv5luC14DGB7eg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.6.tgz",
+      "integrity": "sha512-RE5AP4JmEm/CV06gOyFdgWWm3gMNOoXulod2mq4ysiz9s77ZhHb1P1DGrfePHjNOmgvWglhegmj5q8DNtjRrEg==",
       "requires": {}
     },
     "diff": {
@@ -3889,6 +4167,11 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -3952,6 +4235,14 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-flag": {
       "version": "4.0.0",
@@ -4029,6 +4320,14 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-extglob": {
@@ -4145,7 +4444,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -4304,6 +4602,11 @@
         }
       }
     },
+    "module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4390,6 +4693,11 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
     "path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -4459,6 +4767,26 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-in-the-middle": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      }
+    },
+    "resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "requires": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4499,7 +4827,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -4593,6 +4920,11 @@
         "has-flag": "^4.0.0"
       }
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4646,8 +4978,7 @@
     "typescript": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "dev": true
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -4748,8 +5079,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs-unparser": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vscode/extension-telemetry",
   "description": "A module for Visual Studio Code extensions to report consistent telemetry.",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "author": {
     "name": "Microsoft Corporation"
   },
@@ -20,10 +20,10 @@
     "compile": "tsc -p 'src/browser/tsconfig.json' && tsc -p 'src/node/tsconfig.json'"
   },
   "dependencies": {
-    "@microsoft/1ds-core-js": "^3.2.9",
-    "@microsoft/1ds-post-js": "^3.2.9",
-    "@microsoft/applicationinsights-web-basic": "^2.8.11",
-    "applicationinsights": "2.5.0"
+    "@microsoft/1ds-core-js": "^3.2.10",
+    "@microsoft/1ds-post-js": "^3.2.10",
+    "@microsoft/applicationinsights-web-basic": "^3.0.0",
+    "applicationinsights": "2.6.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/src/common/baseTelemetryReporter.ts
+++ b/src/common/baseTelemetryReporter.ts
@@ -165,51 +165,6 @@ export class BaseTelemetryReporter {
 	}
 
 	/**
-	 * Internal function which logs telemetry exceptions and takes extra options
-	 * @param error: The error to send
-	 * @param properties The properties of the event
-	 * @param measurements The measurements (numeric values) to send with the event
-	 * @param sanitize Whether or not to sanitize to the properties and measures
-	 * @param dangerous Whether or not to ignore telemetry level
-	 */
-	private internalSendTelemetryException(
-		error: Error,
-		properties: TelemetryEventProperties | undefined,
-		measurements: TelemetryEventMeasurements | undefined,
-		dangerous: boolean
-	): void {
-		if (dangerous) {
-			this.telemetrySender.sendErrorData(error, { properties, measurements });
-		} else {
-			this.telemetryLogger.logError(error, { properties, measurements });
-		}
-	}
-
-	/**
-	 * Given an error, properties, and measurements. Sends an exception event
-	 * @param error The error to send
-	 * @param properties The properties to send with the event
-	 * @param measurements The measurements (numeric values) to send with the event
-	 */
-	public sendTelemetryException(error: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
-		this.internalSendTelemetryException(error, properties, measurements, false);
-	}
-
-	/**
-	 * **DANGEROUS** Given an error, properties, and measurements. Sends an exception event without checking the telemetry setting
-	 * Do not use unless in a controlled environment i.e. sending telmetry from a CI pipeline or testing during development
-	 * @param eventName The name of the event
-	 * @param properties The properties to send with the event
-	 * @param measurements The measurements (numeric values) to send with the event
-	 * @param sanitize Whether or not to sanitize to the properties and measures, defaults to true
-	 */
-	public sendDangerousTelemetryException(error: Error, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
-		// Since telemetry is probably off when sending dangerously, we must start the sender
-		this.telemetrySender.instantiateSender();
-		this.internalSendTelemetryException(error, properties, measurements, true);
-	}
-
-	/**
 	 * Disposes of the telemetry reporter
 	 */
 	public dispose(): Promise<any> {

--- a/src/common/baseTelemetrySender.ts
+++ b/src/common/baseTelemetrySender.ts
@@ -70,7 +70,7 @@ export class BaseTelemetrySender implements ILazyTelemetrySender {
 			}
 			return;
 		}
-		// No-op TODO @lramos15 convert into an unhandled error event
+		throw new Error("Attempted to send error data when the @vscode/extension-telemetry module does not support it.");
 	}
 
 	/**


### PR DESCRIPTION
Fixes #152


After further investigation both 1DS and App insights on the web don't support the `trackException` function which makes the experience different for consumers based on telemetry system and architecture it's being run on. The point of this module was to abstract away these differences and to allow for a unified experience. I've decided to remove the ability to log a raw exception and instead it will be up to consumers to break the error object down ito a set of properties and send it via the `sendTelemetryErrorEvent`. This allows them to specify their chosen name without the module making any assumptions about their specific telemetry needs.


Unfortunately this is a breaking change.