### PR TITLE
Better handle teardown of 1DS client

### DIFF
--- a/src/common/1dsClientFactory.ts
+++ b/src/common/1dsClientFactory.ts
@@ -84,7 +84,6 @@ export const oneDataSystemClientFactory = async (key: string, vscodeAPI: typeof 
 		},
 		flush: async () => {
 			try {
-				// Create a promise
 				const flushPromise = new Promise<void>((resolve, reject) => {
 					if (!appInsightsCore) {
 						resolve();

--- a/src/common/1dsClientFactory.ts
+++ b/src/common/1dsClientFactory.ts
@@ -92,9 +92,11 @@ export const oneDataSystemClientFactory = async (key: string, vscodeAPI: typeof 
 					appInsightsCore.flush(true, (completedFlush) => {
 						if (!completedFlush) {
 							reject("Failed to flush app 1DS!");
+							return;
 						}
 						appInsightsCore.unload(true, () => {
 							resolve();
+							return;
 						});
 					});
 				});

--- a/src/common/1dsClientFactory.ts
+++ b/src/common/1dsClientFactory.ts
@@ -84,9 +84,24 @@ export const oneDataSystemClientFactory = async (key: string, vscodeAPI: typeof 
 		},
 		flush: async () => {
 			try {
-				appInsightsCore?.unload();
+				// Create a promise
+				const flushPromise = new Promise<void>((resolve, reject) => {
+					if (!appInsightsCore) {
+						resolve();
+						return;
+					}
+					appInsightsCore.flush(true, (completedFlush) => {
+						if (!completedFlush) {
+							reject("Failed to flush app 1DS!");
+						}
+						appInsightsCore.unload(true, () => {
+							resolve();
+						});
+					});
+				});
+				return flushPromise;
 			} catch (e: any) {
-				throw new Error("Failed to flush app insights!\n" + e.message);
+				throw new Error("Failed to flush 1DS!\n" + e.message);
 			}
 		}
 	};


### PR DESCRIPTION
We were unloading the 1DS client, but not flushing the buffer.