### PR TITLE
Remove deprecated method from type declaration file

### DIFF
--- a/dist/telemetryReporter.d.ts
+++ b/dist/telemetryReporter.d.ts
@@ -57,14 +57,6 @@ export default class TelemetryReporter {
 	sendTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
 
 	/**
-	 * Sends a raw (unsanitized) telemetry event with the given properties and measurements
-	 * @param eventName The name of the event
-	 * @param properties The set of properties to add to the event in the form of a string key value pair
-	 * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
-	 */
-	sendRawTelemetryEvent(eventName: string, properties?: RawTelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
-
-	/**
 	 * **DANGEROUS** Given an event name, some properties, and measurements sends a telemetry event without checking telemetry setting
 	 * Do not use unless in a controlled environment i.e. sending telmetry from a CI pipeline or testing during development
 	 * @param eventName The name of the event


### PR DESCRIPTION
The method that sends a raw (unsanitized) telemetry event `sendRawTelemetryEvent` is declared but not implemented.