### PR TITLE
Add support `TelemetryTrustedValue` instead `sendRawTelemetryEvent` method

### DIFF
--- a/dist/telemetryReporter.d.ts
+++ b/dist/telemetryReporter.d.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 export interface TelemetryEventProperties {
-	readonly [key: string]: string | undefined;
+	readonly [key: string]: string | import("vscode").TelemetryTrustedValue;
 }
 
 export interface TelemetryEventMeasurements {
@@ -51,15 +51,6 @@ export default class TelemetryReporter {
 	 * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
 	 */
 	sendTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
-
-	/**
-	 * Sends a raw (unsanitized) telemetry event with the given properties and measurements
-	 * NOTE: This will not be logged to the output channel due to API limitations.
-	 * @param eventName The name of the event
-	 * @param properties The set of properties to add to the event in the form of a string key value pair
-	 * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
-	 */
-	sendRawTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void;
 
 	/**
 	 * **DANGEROUS** Given an event name, some properties, and measurements sends a telemetry event without checking telemetry setting

--- a/src/common/baseTelemetryReporter.ts
+++ b/src/common/baseTelemetryReporter.ts
@@ -105,21 +105,6 @@ export class BaseTelemetryReporter {
 		this.internalSendTelemetryEvent(eventName, properties, measurements, false);
 	}
 
-
-	/**
-	 * Sends a raw (unsanitized) telemetry event with the given properties and measurements.
-	 * NOTE: This will not be logged to the output channel due to API limitations.
-	 * @param eventName The name of the event
-	 * @param properties The set of properties to add to the event in the form of a string key value pair
-	 * @param measurements The set of measurements to add to the event in the form of a string key  number value pair
-	 */
-	public sendRawTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
-		// Check level then send off dangerously which skips the API as the API sanitizes everything.
-		if (this.telemetryLevel === "all") {
-			this.internalSendTelemetryEvent(eventName, properties, measurements, true);
-		}
-	}
-
 	/**
 	 * **DANGEROUS** Given an event name, some properties, and measurements sends a telemetry event without checking telemetry setting
 	 * Do not use unless in a controlled environment i.e. sending telmetry from a CI pipeline or testing during development


### PR DESCRIPTION
To send raw (unsanitized) data there is a special value wrapper [TelemetryTrustedValue](https://code.visualstudio.com/api/references/vscode-api#TelemetryTrustedValue). Its use would be more correct instead of the `sendRawTelemetryEvent` method, which will only work if `telemetryLevel === "all"`, and data mixing will not occur with it (vscode will not add parameters such as OS, Platform Version, Extension Version, VS Code Version etc. to the telemetry data).

Usage TelemetryTrustedValue:

```typescript
import { TelemetryTrustedValue } from "vscode";

const data = {"foo": "bar"};
const trustedData = new TelemetryTrustedValue(data);
telemetryReporter.sendTelemetryEvent("someEvent", {data: trustedData)};
```