### PR TITLE
Use VS code types that match the engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.4.9",
         "@types/sinon": "^10.0.16",
-        "@types/vscode": "^1.81.0",
+        "@types/vscode": "^1.75.0",
         "@typescript-eslint/eslint-plugin": "^6.3.0",
         "@typescript-eslint/parser": "^6.3.0",
         "eslint": "^8.46.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.4.9",
     "@types/sinon": "^10.0.16",
-    "@types/vscode": "^1.81.0",
+    "@types/vscode": "^1.75.0",
     "@typescript-eslint/eslint-plugin": "^6.3.0",
     "@typescript-eslint/parser": "^6.3.0",
     "eslint": "^8.46.0",


### PR DESCRIPTION
Use a VS Code type version that matches the engine version to avoid any unsuspecting breaking changes caused by later API. 

