### PR TITLE
Send the value assigned to the telemetry property key not the property key itself

### DIFF
--- a/src/common/baseTelemetryReporter.ts
+++ b/src/common/baseTelemetryReporter.ts
@@ -118,7 +118,7 @@ export class BaseTelemetryReporter {
 		for (const property of Object.keys(modifiedProperties ?? {})) {
 			if (typeof property === "string") {
 				// Trusted values are not sanitized, which is what we want for raw telemetry
-				modifiedProperties[property] = new this.vscodeAPI.TelemetryTrustedValue<string>(property);
+				modifiedProperties[property] = new this.vscodeAPI.TelemetryTrustedValue<string>(modifiedProperties[property]);
 			}
 		}
 

--- a/src/common/baseTelemetryReporter.ts
+++ b/src/common/baseTelemetryReporter.ts
@@ -115,10 +115,11 @@ export class BaseTelemetryReporter {
 	 */
 	public sendRawTelemetryEvent(eventName: string, properties?: TelemetryEventProperties, measurements?: TelemetryEventMeasurements): void {
 		const modifiedProperties = { ...properties };
-		for (const property of Object.keys(modifiedProperties ?? {})) {
-			if (typeof property === "string") {
+		for (const propertyKey of Object.keys(modifiedProperties ?? {})) {
+			const propertyValue = modifiedProperties[propertyKey];
+			if (typeof propertyKey === "string" && propertyValue !== undefined) {
 				// Trusted values are not sanitized, which is what we want for raw telemetry
-				modifiedProperties[property] = new this.vscodeAPI.TelemetryTrustedValue<string>(modifiedProperties[property]);
+				modifiedProperties[propertyKey] = new this.vscodeAPI.TelemetryTrustedValue<string>(typeof propertyValue === 'string' ? propertyValue : propertyValue.value);
 			}
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-extension-telemetry/issues/181

Fixes an issues found by the Copilot data science team 

cc @yemohyleyemohyle