### PR TITLE
Less time for teardown

### DIFF
--- a/src/browser/telemetryReporter.ts
+++ b/src/browser/telemetryReporter.ts
@@ -43,12 +43,11 @@ const webAppInsightsClientFactory = async (key: string, replacementOptions?: Rep
 			appInsightsClient?.flush(false);
 		},
 		dispose: async () => {
-			appInsightsClient?.flush(true);
 			const unloadPromise = new Promise<void>((resolve) => {
 				appInsightsClient?.unload(true, () => {
 					resolve();
 					appInsightsClient = undefined;
-				});
+				}, 1000);
 			}
 			);
 			return unloadPromise;

--- a/src/common/1dsClientFactory.ts
+++ b/src/common/1dsClientFactory.ts
@@ -103,17 +103,16 @@ export const oneDataSystemClientFactory = async (key: string, vscodeAPI: typeof 
 		},
 		flush: flushOneDS,
 		dispose: async () => {
-			await flushOneDS();
 			const disposePromise = new Promise<void>((resolve) => {
 				if (!appInsightsCore) {
 					resolve();
 					return;
 				}
-				appInsightsCore.unload(true, () => {
+				appInsightsCore.unload(false, () => {
 					resolve();
 					appInsightsCore = undefined;
 					return;
-				});
+				}, 1000);
 			});
 			return disposePromise;
 		}

--- a/src/node/telemetryReporter.ts
+++ b/src/node/telemetryReporter.ts
@@ -79,7 +79,7 @@ const appInsightsClientFactory = async (key: string, replacementOptions?: Replac
 			}
 		},
 		dispose: async () => {
-			appInsightsClient?.flush();
+			appInsightsClient?.flush({ isAppCrashing: true });
 			appInsightsClient = undefined;
 		}
 	};


### PR DESCRIPTION
Shorten the teardown time and make it synchronous. Also skip calling flush as unload will do just that.

Hopefully helps with https://github.com/microsoft/vscode/issues/192742