### PR TITLE
Improve properties capture for the sendErrorData method

### DIFF
--- a/src/common/baseTelemetrySender.ts
+++ b/src/common/baseTelemetrySender.ts
@@ -65,7 +65,7 @@ export class BaseTelemetrySender implements ILazyTelemetrySender {
 	 * @param exception The exception to collect
 	 * @param data Data associated with the exception
 	 */
-	sendErrorData(exception: Error, data?: SenderData): void {
+	sendErrorData(exception: Error, data?: SenderData | Record<string, any>): void {
 		if (!this._telemetryClient) {
 			if (this._instantiationStatus !== InstantiationStatus.INSTANTIATED) {
 				this._exceptionQueue.push({ exception, data });
@@ -74,7 +74,8 @@ export class BaseTelemetrySender implements ILazyTelemetrySender {
 		}
 		const errorData = { stack: exception.stack, message: exception.message, name: exception.name };
 		if (data) {
-			data.properties = { ...data.properties, ...errorData };
+			const errorProperties = data.properties || data;
+			data.properties = { ...errorProperties, ...errorData };
 		} else {
 			data = { properties: errorData };
 		}


### PR DESCRIPTION
Hey, I'm using this package and noticed that all unhandled errors reported by it don't have any common properties (like extension or vscode versions).

It seems like `sender.sendErrorData` doesn't always receive data objects with the `properties` field, in which case common properties that the vscode usually supplies to all events or errors will not be sent.

In the case of unhandled errors vscode itself [calls `sender.sendErrorData` method](https://github.com/microsoft/vscode/blob/a344f294ce1bdb1cefe667488427ce487565b1c6/src/vs/workbench/api/common/extHostTelemetry.ts#L293) providing the data object without `properties` field. 

Internally (and publicly through TelemetryLogger extension API) vscode seem to always treat `data` argument as `Record<string, any>` type. It acknowledges that `properties` might exist [while mixing in common props](https://github.com/microsoft/vscode/blob/a344f294ce1bdb1cefe667488427ce487565b1c6/src/vs/workbench/api/common/extHostTelemetry.ts#L221), but it doesn't create such data objects itself.

This PR accounts for that and fallbacks to using full data object if the `properties` field doesn't exist, fixing the reporting of unhandled errors. 