### PR TITLE
Use clean user agent string instead of `appVersion` when `userAgentData` is unavailable.

### DIFF
--- a/src/browser/telemetryReporter.ts
+++ b/src/browser/telemetryReporter.ts
@@ -14,7 +14,9 @@ function getBrowserRelease(navigator: Navigator): string {
 		const browser = navigator.userAgentData.brands[navigator.userAgentData.brands.length - 1];
 		return `${navigator.userAgentData.platform} - ${browser?.brand} v${browser?.version}}`;
 	} else {
-		return navigator.appVersion;
+		// clean the user agent using the logic from here:
+		// https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/telemetry/browser/workbenchCommonProperties.ts#L14C1-L21C2
+		return navigator.userAgent.replace(/(\d+\.\d+)(\.\d+)+/g, "$1");
 	}
 }
 


### PR DESCRIPTION
Thanks for the library! We use this a lot, and are very happy with its implementation.

This PR aims to replace the usage of the [deprecated `navigator.appVersion`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/appVersion) with a cleaned `userAgent` string, in the case where `userAgentData` is unavailable (all non-chromium browsers, including Safari and Firefox). 