### PR TITLE
Rollback packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@vscode/extension-telemetry",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/extension-telemetry",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "^4.1.1",
-        "@microsoft/1ds-post-js": "^4.1.1",
-        "@microsoft/applicationinsights-web-basic": "^3.1.1"
+        "@microsoft/1ds-core-js": "^4.0.6",
+        "@microsoft/1ds-post-js": "^4.0.6",
+        "@microsoft/applicationinsights-web-basic": "^3.0.8"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vscode/extension-telemetry",
   "description": "A module for Visual Studio Code extensions to report consistent telemetry.",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "author": {
     "name": "Microsoft Corporation"
   },
@@ -20,9 +20,9 @@
     "compile": "tsc -p src/browser/tsconfig.json && tsc -p src/node/tsconfig.json"
   },
   "dependencies": {
-    "@microsoft/1ds-core-js": "^4.1.1",
-    "@microsoft/1ds-post-js": "^4.1.1",
-    "@microsoft/applicationinsights-web-basic": "^3.1.1"
+    "@microsoft/1ds-core-js": "^4.0.6",
+    "@microsoft/1ds-post-js": "^4.0.6",
+    "@microsoft/applicationinsights-web-basic": "^3.0.8"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.3",

--- a/src/common/1dsClientFactory.ts
+++ b/src/common/1dsClientFactory.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { AppInsightsCore, IExtendedConfiguration } from "@microsoft/1ds-core-js";
+import type { AppInsightsCore, IExtendedConfiguration, IPerfManager } from "@microsoft/1ds-core-js";
 import type { IChannelConfiguration, IXHROverride, PostChannel } from "@microsoft/1ds-post-js";
 import type * as vscode from "vscode";
 import type { BaseTelemetryClient } from "./baseTelemetrySender";
@@ -20,6 +20,19 @@ const getAICore = async (key: string, vscodeAPI: typeof vscode, xhrOverride?: IX
 	const postPlugin = await import(/* webpackMode: "eager" */ "@microsoft/1ds-post-js");
 	const appInsightsCore = new oneDs.AppInsightsCore();
 	const collectorChannelPlugin: PostChannel = new postPlugin.PostChannel();
+
+	// Dummy perf manager to fix memory leaks
+	const perfManager: IPerfManager = {
+		create: function (_src, _payload, _isAsync) {
+			return null;
+		},
+		fire: function (_perfEvent) {
+		},
+		setCtx: function (_key, _value) {
+		},
+		getCtx: function (_key) {
+		}
+	};
 	// Configure the app insights core to send to collector++ and disable logging of debug info
 	const coreConfig: IExtendedConfiguration = {
 		instrumentationKey: key,
@@ -28,6 +41,9 @@ const getAICore = async (key: string, vscodeAPI: typeof vscode, xhrOverride?: IX
 		loggingLevelConsole: 0,
 		disableCookiesUsage: true,
 		disableDbgExt: true,
+		createPerfMgr: () => {
+			return perfManager;
+		},
 		disableInstrumentationKeyValidation: true,
 		channels: [[
 			collectorChannelPlugin


### PR DESCRIPTION
Rollback some telemetry packages due to
https://github.com/microsoft/ApplicationInsights-JS/issues/2311
and
https://github.com/microsoft/ApplicationInsights-JS/issues/2306
and
https://github.com/microsoft/ApplicationInsights-JS/issues/2307