### PR TITLE
Propagate session ID metadata

### DIFF
--- a/src/browser/telemetryReporter.ts
+++ b/src/browser/telemetryReporter.ts
@@ -22,7 +22,7 @@ function getBrowserRelease(navigator: Navigator): string {
 
 export default class TelemetryReporter extends BaseTelemetryReporter {
 	constructor(connectionString: string, replacementOptions?: ReplacementOption[]) {
-		let clientFactory = (connectionString: string) => appInsightsClientFactory(connectionString, vscode.env.machineId, undefined, replacementOptions);
+		let clientFactory = (connectionString: string) => appInsightsClientFactory(connectionString, vscode.env.machineId, vscode.env.sessionId, undefined, replacementOptions);
 		// If key is usable by 1DS use the 1DS SDk
 		if (TelemetryUtil.shouldUseOneDataSystemSDK(connectionString)) {
 			clientFactory = (key: string) => oneDataSystemClientFactory(key, vscode);

--- a/src/common/appInsightsClientFactory.ts
+++ b/src/common/appInsightsClientFactory.ts
@@ -11,7 +11,7 @@ import { ReplacementOption, SenderData } from "./baseTelemetryReporter";
 import { BaseTelemetryClient } from "./baseTelemetrySender";
 import { TelemetryUtil } from "./util";
 
-export const appInsightsClientFactory = async (connectionString: string, machineId: string, xhrOverride?: IXHROverride, replacementOptions?: ReplacementOption[]): Promise<BaseTelemetryClient> => {
+export const appInsightsClientFactory = async (connectionString: string, machineId: string, sessionId: string, xhrOverride?: IXHROverride, replacementOptions?: ReplacementOption[]): Promise<BaseTelemetryClient> => {
 	let appInsightsClient: ApplicationInsights | undefined;
 	try {
 		const basicAISDK = await import/* webpackMode: "eager" */("@microsoft/applicationinsights-web-basic");
@@ -52,7 +52,7 @@ export const appInsightsClientFactory = async (connectionString: string, machine
 				name: eventName,
 				data: properties,
 				baseType: "EventData",
-				ext: { user: { id: machineId, authId: machineId } },
+				ext: { user: { id: machineId, authId: machineId }, app: { sesId: sessionId } },
 				baseData: { name: eventName, properties: data?.properties, measurements: data?.measurements }
 			});
 		},

--- a/src/node/telemetryReporter.ts
+++ b/src/node/telemetryReporter.ts
@@ -55,7 +55,7 @@ function getXHROverride() {
 
 export default class TelemetryReporter extends BaseTelemetryReporter {
 	constructor(connectionString: string, replacementOptions?: ReplacementOption[]) {
-		let clientFactory = (connectionString: string) => appInsightsClientFactory(connectionString, vscode.env.machineId, getXHROverride(), replacementOptions);
+		let clientFactory = (connectionString: string) => appInsightsClientFactory(connectionString, vscode.env.machineId, vscode.env.sessionId, getXHROverride(), replacementOptions);
 		// If connection string is usable by 1DS use the 1DS SDk
 		if (TelemetryUtil.shouldUseOneDataSystemSDK(connectionString)) {
 			clientFactory = (key: string) => oneDataSystemClientFactory(key, vscode, getXHROverride());


### PR DESCRIPTION
This PR adds session ID metadata when reporting events.

Before this change, all events would be collected under a single session under Application Insights. It makes it hard to isolate reported events and reason how often users launch the extension.

In this PR, we use vscode's env `sessionId` field to pass it as session identifier when reporting app insight events (via `app.sesId` field).