### PR TITLE
Remove extraneous brace from common.platformversion

### DIFF
--- a/src/browser/telemetryReporter.ts
+++ b/src/browser/telemetryReporter.ts
@@ -12,7 +12,7 @@ import { TelemetryUtil } from "../common/util";
 function getBrowserRelease(navigator: Navigator): string {
 	if (navigator.userAgentData) {
 		const browser = navigator.userAgentData.brands[navigator.userAgentData.brands.length - 1];
-		return `${navigator.userAgentData.platform} - ${browser?.brand} v${browser?.version}}`;
+		return `${navigator.userAgentData.platform} - ${browser?.brand} v${browser?.version}`;
 	} else {
 		// clean the user agent using the logic from here:
 		// https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/telemetry/browser/workbenchCommonProperties.ts#L14C1-L21C2


### PR DESCRIPTION
Our extension telemetry contains values such as `Windows - Chromium v128}`, `macOS - Chromium v128}`, `Linux - Chromium v128}` etc. I assume this wasn't intentional. (Please disregard if it was).