### PR TITLE
No more default export for the TelemetryReporter

### DIFF
--- a/dist/telemetryReporter.d.ts
+++ b/dist/telemetryReporter.d.ts
@@ -26,7 +26,7 @@ export interface ReplacementOption {
 	replacementString?: string;
 }
 
-export default class TelemetryReporter {
+export class TelemetryReporter {
 	/**
 	 * @param connectionString The app insights connection string
 	 * @param replacementOptions A list of replacement options for the app insights client. This allows the sender to filter out any sensitive or unnecessary information from the telemetry server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/extension-telemetry",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/extension-telemetry",
-      "version": "0.9.9",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@microsoft/1ds-core-js": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vscode/extension-telemetry",
   "description": "A module for Visual Studio Code extensions to report consistent telemetry.",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/browser/telemetryReporter.ts
+++ b/src/browser/telemetryReporter.ts
@@ -20,7 +20,7 @@ function getBrowserRelease(navigator: Navigator): string {
 	}
 }
 
-export default class TelemetryReporter extends BaseTelemetryReporter {
+export class TelemetryReporter extends BaseTelemetryReporter {
 	constructor(connectionString: string, replacementOptions?: ReplacementOption[]) {
 		let clientFactory = (connectionString: string) => appInsightsClientFactory(connectionString, vscode.env.machineId, vscode.env.sessionId, undefined, replacementOptions);
 		// If key is usable by 1DS use the 1DS SDk

--- a/src/node/telemetryReporter.ts
+++ b/src/node/telemetryReporter.ts
@@ -53,7 +53,7 @@ function getXHROverride() {
 	return customHttpXHROverride;
 }
 
-export default class TelemetryReporter extends BaseTelemetryReporter {
+export class TelemetryReporter extends BaseTelemetryReporter {
 	constructor(connectionString: string, replacementOptions?: ReplacementOption[]) {
 		let clientFactory = (connectionString: string) => appInsightsClientFactory(connectionString, vscode.env.machineId, vscode.env.sessionId, getXHROverride(), replacementOptions);
 		// If connection string is usable by 1DS use the 1DS SDk


### PR DESCRIPTION
Makes it simpler to use this module as ESM and CJS

This should fix https://github.com/microsoft/vscode-extension-telemetry/issues/222