### PR TITLE
setdefault content type to json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/extension-telemetry",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/extension-telemetry",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@microsoft/1ds-core-js": "^4.3.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vscode/extension-telemetry",
   "description": "A module for Visual Studio Code extensions to report consistent telemetry.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/node/telemetryReporter.ts
+++ b/src/node/telemetryReporter.ts
@@ -77,8 +77,13 @@ function createXHROverrideFromFetcher(fetcher: CustomFetcher): IXHROverride {
 	const xhrOverride: IXHROverride = {
 		sendPOST: (payload: IPayloadData, oncomplete) => {
 			const dataString = typeof payload.data === "string" ? payload.data : Buffer.from(payload.data).toString();
+			const headers: Record<string, string> = { ...payload.headers };
+			// if the content-type header isn't already set, default it to application/json
+			if (!Object.keys(headers).some(k => k.toLowerCase() === "content-type")) {
+				headers["Content-Type"] = "application/json";
+			}
 
-			fetcher(payload.urlString, { method: "POST", headers: payload.headers, body: dataString })
+			fetcher(payload.urlString, { method: "POST", headers, body: dataString })
 				.then(async (response) => {
 					const responseHeaders: Record<string, string> = {};
 					for (const [key, value] of response.headers) {


### PR DESCRIPTION
setdefault content type to json when its not already set. appInsights web js defaults to `text/plain` which is incorrect for telemetry payload.